### PR TITLE
高音保护优化与首次使用引导添加

### DIFF
--- a/app/api/bridge.py
+++ b/app/api/bridge.py
@@ -654,6 +654,9 @@ class Api:
     def toggle_model_favorite(self, model_id: str) -> dict[str, Any] | None:
         return self._models.toggle_favorite(model_id)
 
+    def rename_model(self, model_id: str, name: str) -> bool:
+        return self._models.rename(model_id, name) is not None
+
     # ---- 模型站（ModelScope 魔搭社区）----
     def get_modelscope_token(self) -> str:
         return self._hub.get_token()
@@ -817,6 +820,29 @@ class Api:
             ),
         )
         return list(result or [])
+
+    def import_audio_data(self, name: str, data: str) -> str | None:
+        """Persist a browser/drag-and-drop audio payload for a pending work."""
+        raw = str(data or "")
+        if raw.startswith("data:") and "," in raw:
+            raw = raw.split(",", 1)[1]
+        try:
+            content = base64.b64decode(raw, validate=True)
+        except Exception:
+            return None
+        if not content or len(content) > 50 * 1024 * 1024:
+            return None
+        suffix = Path(str(name or "audio.wav")).suffix.lower()
+        if suffix not in {".mp3", ".wav", ".flac", ".m4a", ".ogg", ".aac", ".opus", ".wma"}:
+            return None
+        target_dir = config.TEMP_DIR / "dropped-audio"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / f"{paths.new_id('drop_')}{suffix}"
+        try:
+            target.write_bytes(content)
+        except OSError:
+            return None
+        return str(target)
 
     def pick_lyrics_file(self) -> dict[str, Any]:
         result = self._open_dialog(

--- a/app/api/http_server.py
+++ b/app/api/http_server.py
@@ -576,6 +576,7 @@ JOB_CREATE_API_DOC = _api_operation_description(
         ("params.ddsp_infer_steps", "integer", "否", "50", "仅 DDSP；采样步数，最小 1，推荐 50~100"),
         ("params.ddsp_formant_shift", "number", "否", "0", "仅 DDSP；共振峰半音偏移，范围 -2~2"),
         ("params.auto_high_pitch_guard", "boolean", "否", "true", "翻唱/实时变声；极高音先保共振峰降调，翻唱后升回原调并补偿响度"),
+        ("params.high_pitch_guard_rounds", "integer", "否", "3", "高音保护重试轮次，范围 0~8"),
         ("vocal_enhancement.enabled", "boolean", "否", "false", "启用自然修音、AI 角色共振峰与歌声增强"),
         ("vocal_enhancement.level", "string", "否", "basic", "basic 或 advanced"),
         ("vocal_enhancement.pitch_correction", "number", "否", "0.45", "自然修音强度，范围 0~1"),
@@ -851,6 +852,29 @@ class InferenceParamsRequest(BaseModel):
         default=True,
         description="高音保护：极高音先保共振峰降调，经过模型翻唱后再升回原调，并补偿高音响度。",
     )
+    high_pitch_guard_rounds: int = Field(
+        default=3,
+        ge=0,
+        le=8,
+        description="高音保护重试轮次；0 表示不进行保护重试。",
+    )
+    high_pitch_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=2000.0,
+        description="兼容旧客户端的高音保护起点；0 表示自动。",
+        deprecated=True,
+    )
+    f0_filter_threshold: float = Field(
+        default=0.05,
+        ge=0.0,
+        le=1.0,
+        description="F0 过滤阈值，范围 0~1。",
+    )
+    manual_params_enabled: bool = Field(
+        default=False,
+        description="是否启用全参数手动调整。",
+    )
 
 
 class VocalEnhancementRequest(BaseModel):
@@ -1072,6 +1096,12 @@ class ModelDefaultRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     model_id: str = Field(description="设为默认项的声音模型 ID")
+
+
+class ModelRenameRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=120, description="新的模型显示名称")
 
 
 class EditorProjectCreateRequest(BaseModel):
@@ -1890,6 +1920,23 @@ def create_http_app(facade: "Api", api_key: str) -> FastAPI:
             raise HTTPException(status_code=404, detail="模型不存在")
         return _public_model(item)
 
+    @router.patch(
+        "/models/{model_id}",
+        response_model=ModelResponse,
+        tags=["模型"],
+        summary="重命名声音模型",
+        description="仅修改模型显示名称，不会修改模型权重、配置或模型 ID。",
+        responses={404: {"model": ErrorResponse, "description": "模型 ID 不存在"}},
+    )
+    def rename_model(
+        request: ModelRenameRequest,
+        model_id: str = ApiPath(..., description="声音模型 ID"),
+    ) -> dict[str, Any]:
+        item = facade._models.rename(model_id, request.name)
+        if not item:
+            raise HTTPException(status_code=404, detail="模型不存在或名称无效")
+        return _public_model(item)
+
     @router.post(
         "/models/{model_id}/favorite",
         response_model=ModelResponse,
@@ -2069,6 +2116,8 @@ def create_http_app(facade: "Api", api_key: str) -> FastAPI:
             selected_ids: set[str] = set()
             shared_guard_explicit = "auto_high_pitch_guard" in request.params.model_fields_set
             shared_guard = request.params.auto_high_pitch_guard
+            shared_rounds_explicit = "high_pitch_guard_rounds" in request.params.model_fields_set
+            shared_rounds = request.params.high_pitch_guard_rounds
             for entry in request.models:
                 if entry.model_id in selected_ids:
                     raise HTTPException(status_code=422, detail=f"models 中模型重复：{entry.model_id}")
@@ -2085,6 +2134,11 @@ def create_http_app(facade: "Api", api_key: str) -> FastAPI:
                     and "auto_high_pitch_guard" not in entry.params.model_fields_set
                 ):
                     params["auto_high_pitch_guard"] = shared_guard
+                if (
+                    shared_rounds_explicit
+                    and "high_pitch_guard_rounds" not in entry.params.model_fields_set
+                ):
+                    params["high_pitch_guard_rounds"] = shared_rounds
                 if entry.reference_upload_id:
                     params["reference_audio"] = str(_resolve_upload(entry.reference_upload_id))
                 if str(model.get("framework") or "") == "seed-vc" and not params.get(

--- a/app/application/audio_editor_service.py
+++ b/app/application/audio_editor_service.py
@@ -1933,6 +1933,7 @@ class AudioEditorService:
         params: InferenceParams,
         model: dict[str, Any] | None = None,
         only_regions: list[tuple[float, float]] | None = None,
+        semitones: int | None = None,
     ) -> tuple[Path, bool]:
         if not params.auto_high_pitch_guard or not source.is_file():
             return source, False
@@ -1951,11 +1952,12 @@ class AudioEditorService:
             }
             if only_regions:
                 kwargs["regions"] = only_regions
-            ok = pitch_shift(source, destination, -self._HIGH_PITCH_GUARD_SEMITONES, **kwargs)
+            shift_semitones = int(semitones or self._HIGH_PITCH_GUARD_SEMITONES)
+            ok = pitch_shift(source, destination, -shift_semitones, **kwargs)
         except TypeError:
             if only_regions:
                 return source, False
-            ok = pitch_shift(source, destination, -self._HIGH_PITCH_GUARD_SEMITONES)
+            ok = pitch_shift(source, destination, -int(semitones or self._HIGH_PITCH_GUARD_SEMITONES))
         return (destination, True) if ok and destination.is_file() else (source, False)
 
     def _restore_high_pitch_guard(
@@ -1966,6 +1968,7 @@ class AudioEditorService:
         params: InferenceParams,
         model: dict[str, Any] | None = None,
         only_regions: list[tuple[float, float]] | None = None,
+        semitones: int | None = None,
     ) -> Path:
         if not params.auto_high_pitch_guard:
             return source
@@ -1980,11 +1983,12 @@ class AudioEditorService:
             }
             if only_regions:
                 kwargs["regions"] = only_regions
-            ok = pitch_shift(source, destination, self._HIGH_PITCH_GUARD_SEMITONES, **kwargs)
+            shift_semitones = int(semitones or self._HIGH_PITCH_GUARD_SEMITONES)
+            ok = pitch_shift(source, destination, shift_semitones, **kwargs)
         except TypeError:
             if only_regions:
                 return source
-            ok = pitch_shift(source, destination, self._HIGH_PITCH_GUARD_SEMITONES)
+            ok = pitch_shift(source, destination, int(semitones or self._HIGH_PITCH_GUARD_SEMITONES))
         return destination if ok and destination.is_file() else source
 
     def _infer_with_dropout_recovery(
@@ -2010,6 +2014,7 @@ class AudioEditorService:
         guard_applied_any = False
         rendered = output
         guard_regions: list[tuple[float, float]] | None = None
+        guard_semitones = self._HIGH_PITCH_GUARD_SEMITONES
         for attempt in range(attempts):
             raw_target = output if attempt == 0 else output.with_name(
                 f"{output.stem}_dropout_retry{attempt}.wav"
@@ -2023,6 +2028,7 @@ class AudioEditorService:
                     params,
                     profile,
                     guard_regions,
+                    guard_semitones,
                 )
             guard_applied_any = guard_applied_any or guard_applied
             engine.infer(model, guarded, raw_target, params, duration)
@@ -2036,6 +2042,7 @@ class AudioEditorService:
                     params,
                     profile,
                     guard_regions,
+                    guard_semitones,
                 )
                 if candidate != raw_target:
                     rendered = candidate
@@ -2062,12 +2069,27 @@ class AudioEditorService:
                     if isinstance(item, dict)
                     and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
                 ] or guard_regions
+                guard_semitones = ConversionService._guard_semitones_for_retry(
+                    threshold,
+                    issue,
+                    source,
+                    guard_regions,
+                )
             if issue is None:
                 return rendered, history, guard_applied_any
             next_threshold = ConversionService._next_dropout_threshold(threshold, issue)
             entry["next_threshold"] = next_threshold
             if next_threshold >= threshold - 10.0 or attempt >= attempts - 1:
                 return rendered, history, guard_applied_any
+            guard_semitones = max(
+                guard_semitones,
+                ConversionService._guard_semitones_for_retry(
+                    next_threshold,
+                    issue,
+                    source,
+                    guard_regions,
+                ),
+            )
             threshold = next_threshold
             params.high_pitch_threshold = threshold
         return rendered, history, guard_applied_any

--- a/app/application/audio_editor_service.py
+++ b/app/application/audio_editor_service.py
@@ -1931,11 +1931,13 @@ class AudioEditorService:
         source: Path,
         destination: Path,
         params: InferenceParams,
+        model: dict[str, Any] | None = None,
     ) -> tuple[Path, bool]:
         if not params.auto_high_pitch_guard or not source.is_file():
             return source, False
         peak_f0 = self._estimate_peak_f0(source)
-        if peak_f0 < self._HIGH_PITCH_THRESHOLD:
+        high_threshold = self._model_high_pitch_threshold(params, model)
+        if peak_f0 < high_threshold:
             return source, False
         pitch_shift = getattr(self._ffmpeg, "pitch_shift", None)
         if not callable(pitch_shift):
@@ -1946,7 +1948,7 @@ class AudioEditorService:
             -self._HIGH_PITCH_GUARD_SEMITONES,
             mask_source=source,
             loudness_source=source,
-            high_threshold=self._HIGH_PITCH_THRESHOLD,
+            high_threshold=high_threshold,
         )
         return (destination, True) if ok and destination.is_file() else (source, False)
 
@@ -1956,6 +1958,7 @@ class AudioEditorService:
         destination: Path,
         original: Path,
         params: InferenceParams,
+        model: dict[str, Any] | None = None,
     ) -> Path:
         if not params.auto_high_pitch_guard:
             return source
@@ -1968,9 +1971,128 @@ class AudioEditorService:
             self._HIGH_PITCH_GUARD_SEMITONES,
             mask_source=original,
             loudness_source=original,
-            high_threshold=self._HIGH_PITCH_THRESHOLD,
+            high_threshold=self._model_high_pitch_threshold(params, model),
         )
         return destination if ok and destination.is_file() else source
+
+    def _infer_with_dropout_recovery(
+        self,
+        *,
+        model: dict[str, Any],
+        profile_model: dict[str, Any] | None = None,
+        engine: Any,
+        source: Path,
+        output: Path,
+        params: InferenceParams,
+        duration: float,
+    ) -> tuple[Path, list[dict[str, Any]], bool]:
+        """Retry an editor clip only when the converted high note collapses."""
+        from application.conversion_service import ConversionService
+
+        profile = profile_model or model
+        threshold = self._model_high_pitch_threshold(params, profile)
+        params.high_pitch_threshold = threshold
+        guard_rounds = ConversionService._high_pitch_guard_rounds(params)
+        attempts = 1 + guard_rounds if params.auto_high_pitch_guard else 1
+        history: list[dict[str, Any]] = []
+        guard_applied_any = False
+        rendered = output
+        for attempt in range(attempts):
+            raw_target = output if attempt == 0 else output.with_name(
+                f"{output.stem}_dropout_retry{attempt}.wav"
+            )
+            if attempt == 0:
+                guarded, guard_applied = source, False
+            else:
+                guarded, guard_applied = self._prepare_high_pitch_guard(
+                    source,
+                    output.with_name(f"{output.stem}_guarded_retry{attempt}.wav"),
+                    params,
+                    profile,
+                )
+            guard_applied_any = guard_applied_any or guard_applied
+            engine.infer(model, guarded, raw_target, params, duration)
+            rendered = raw_target
+            if guard_applied:
+                restored = output.with_name(f"{output.stem}_restored_retry{attempt}.wav")
+                candidate = self._restore_high_pitch_guard(
+                    raw_target,
+                    restored,
+                    source,
+                    params,
+                    profile,
+                )
+                if candidate != raw_target:
+                    rendered = candidate
+            issue = (
+                ConversionService._detect_model_dropout(
+                    source,
+                    rendered,
+                    threshold,
+                    int(getattr(params, "pitch", 0) or 0),
+                )
+                if params.auto_high_pitch_guard and guard_rounds > 0
+                else None
+            )
+            entry: dict[str, Any] = {
+                "attempt": attempt + 1,
+                "threshold": round(threshold, 1),
+                "issue": issue,
+            }
+            history.append(entry)
+            if issue is None:
+                return rendered, history, guard_applied_any
+            next_threshold = ConversionService._next_dropout_threshold(threshold, issue)
+            entry["next_threshold"] = next_threshold
+            if next_threshold >= threshold - 10.0 or attempt >= attempts - 1:
+                return rendered, history, guard_applied_any
+            threshold = next_threshold
+            params.high_pitch_threshold = threshold
+        return rendered, history, guard_applied_any
+
+    @staticmethod
+    def _model_high_pitch_threshold(
+        params: InferenceParams, model: dict[str, Any] | None = None
+    ) -> float:
+        explicit = float(getattr(params, "high_pitch_threshold", 0.0) or 0.0)
+        if explicit > 0:
+            return max(300.0, min(2000.0, explicit))
+        if not bool(getattr(params, "manual_params_enabled", False)):
+            return AudioEditorService._HIGH_PITCH_THRESHOLD
+        model = model or {}
+        metadata = model.get("metadata") or model.get("model_metadata") or {}
+        profile = metadata.get("inference_profile") if isinstance(metadata, dict) else None
+        values = []
+        for source in (metadata, profile if isinstance(profile, dict) else {}):
+            values.extend([source.get("high_pitch_threshold"), source.get("f0_max_hz"), source.get("f0_max")])
+        config_path = str((model.get("main_config") or {}).get("path") or model.get("main_config_path") or "")
+        if config_path:
+            try:
+                raw = Path(config_path).read_text(encoding="utf-8")
+                try:
+                    parsed = json.loads(raw)
+                    def visit(value: Any) -> None:
+                        if isinstance(value, dict):
+                            for key, child in value.items():
+                                if str(key).lower() in {"f0_max", "f0_max_hz", "max_f0"}:
+                                    values.append(child)
+                                visit(child)
+                        elif isinstance(value, list):
+                            for child in value:
+                                visit(child)
+                    visit(parsed)
+                except (TypeError, ValueError):
+                    for key in ("f0_max", "f0_max_hz", "max_f0"):
+                        match = re.search(rf"(?:^|\n)\s*{key}\s*:\s*([0-9]+(?:\.[0-9]+)?)", raw, re.I)
+                        if match: values.append(match.group(1))
+            except OSError:
+                pass
+        for value in values:
+            try: number = float(value)
+            except (TypeError, ValueError): continue
+            if 300.0 <= number <= 2000.0: return number
+        framework = config.modelhub_normalize_framework(model.get("framework"))
+        return {"rvc": 760.0, "seed-vc": 980.0, "ddsp-svc": 1040.0, "so-vits-svc": 1120.0}.get(framework, 1000.0)
 
     def rerun_clip(
         self,
@@ -2021,24 +2143,18 @@ class AudioEditorService:
             return {"ok": False, "error": "片段裁剪失败"}
         model_payload = self._model_payload(model)
         engine = self._engines.for_model(model_payload)
-        guarded_input, guard_applied = self._prepare_high_pitch_guard(
-            dry,
-            out_dir / f"{clip_id}_{rerun_key}_high_guarded.wav",
-            infer_params,
-        )
         try:
-            engine.infer(model_payload, guarded_input, out, infer_params, duration)
+            out, dropout_recovery, guard_applied = self._infer_with_dropout_recovery(
+                model=model_payload,
+                profile_model=model,
+                engine=engine,
+                source=dry,
+                output=out,
+                params=infer_params,
+                duration=duration,
+            )
         except Exception as exc:  # noqa: BLE001 - 需要把推理错误回传给前端
             return {"ok": False, "error": str(exc)}
-        if guard_applied:
-            restored = self._restore_high_pitch_guard(
-                out,
-                out_dir / f"{clip_id}_{model_id}_{rerun_key}_high_restored.wav",
-                dry,
-                infer_params,
-            )
-            if restored != out:
-                out = restored
 
         # 可选增强：以裁剪出的原始干声保护高级层的辅音、呼吸和宽带平衡。
         enhance_used = False
@@ -2129,6 +2245,7 @@ class AudioEditorService:
                 "rerun_dry_effects": True,
                 "rerun_enhanced": enhance_used,
                 "rerun_high_pitch_guard": guard_applied,
+                "rerun_dropout_recovery": dropout_recovery,
                 "rerun_beauty_compensation": guard_applied and enhance_used,
                 "rerun_enhance_level": enhance_level if enhance_used else "",
                 "rerun_pitch_correction": pitch_correction if enhance_used else 0.0,

--- a/app/application/audio_editor_service.py
+++ b/app/application/audio_editor_service.py
@@ -1932,6 +1932,7 @@ class AudioEditorService:
         destination: Path,
         params: InferenceParams,
         model: dict[str, Any] | None = None,
+        only_regions: list[tuple[float, float]] | None = None,
     ) -> tuple[Path, bool]:
         if not params.auto_high_pitch_guard or not source.is_file():
             return source, False
@@ -1942,14 +1943,19 @@ class AudioEditorService:
         pitch_shift = getattr(self._ffmpeg, "pitch_shift", None)
         if not callable(pitch_shift):
             return source, False
-        ok = pitch_shift(
-            source,
-            destination,
-            -self._HIGH_PITCH_GUARD_SEMITONES,
-            mask_source=source,
-            loudness_source=source,
-            high_threshold=high_threshold,
-        )
+        try:
+            kwargs: dict[str, Any] = {
+                "mask_source": source,
+                "loudness_source": source,
+                "high_threshold": high_threshold,
+            }
+            if only_regions:
+                kwargs["regions"] = only_regions
+            ok = pitch_shift(source, destination, -self._HIGH_PITCH_GUARD_SEMITONES, **kwargs)
+        except TypeError:
+            if only_regions:
+                return source, False
+            ok = pitch_shift(source, destination, -self._HIGH_PITCH_GUARD_SEMITONES)
         return (destination, True) if ok and destination.is_file() else (source, False)
 
     def _restore_high_pitch_guard(
@@ -1959,20 +1965,26 @@ class AudioEditorService:
         original: Path,
         params: InferenceParams,
         model: dict[str, Any] | None = None,
+        only_regions: list[tuple[float, float]] | None = None,
     ) -> Path:
         if not params.auto_high_pitch_guard:
             return source
         pitch_shift = getattr(self._ffmpeg, "pitch_shift", None)
         if not callable(pitch_shift):
             return source
-        ok = pitch_shift(
-            source,
-            destination,
-            self._HIGH_PITCH_GUARD_SEMITONES,
-            mask_source=original,
-            loudness_source=original,
-            high_threshold=self._model_high_pitch_threshold(params, model),
-        )
+        try:
+            kwargs = {
+                "mask_source": original,
+                "loudness_source": original,
+                "high_threshold": self._model_high_pitch_threshold(params, model),
+            }
+            if only_regions:
+                kwargs["regions"] = only_regions
+            ok = pitch_shift(source, destination, self._HIGH_PITCH_GUARD_SEMITONES, **kwargs)
+        except TypeError:
+            if only_regions:
+                return source
+            ok = pitch_shift(source, destination, self._HIGH_PITCH_GUARD_SEMITONES)
         return destination if ok and destination.is_file() else source
 
     def _infer_with_dropout_recovery(
@@ -1997,6 +2009,7 @@ class AudioEditorService:
         history: list[dict[str, Any]] = []
         guard_applied_any = False
         rendered = output
+        guard_regions: list[tuple[float, float]] | None = None
         for attempt in range(attempts):
             raw_target = output if attempt == 0 else output.with_name(
                 f"{output.stem}_dropout_retry{attempt}.wav"
@@ -2009,6 +2022,7 @@ class AudioEditorService:
                     output.with_name(f"{output.stem}_guarded_retry{attempt}.wav"),
                     params,
                     profile,
+                    guard_regions,
                 )
             guard_applied_any = guard_applied_any or guard_applied
             engine.infer(model, guarded, raw_target, params, duration)
@@ -2021,6 +2035,7 @@ class AudioEditorService:
                     source,
                     params,
                     profile,
+                    guard_regions,
                 )
                 if candidate != raw_target:
                     rendered = candidate
@@ -2040,6 +2055,13 @@ class AudioEditorService:
                 "issue": issue,
             }
             history.append(entry)
+            if issue and issue.get("bad_regions"):
+                guard_regions = [
+                    (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
+                    for item in (issue.get("bad_regions") or [])
+                    if isinstance(item, dict)
+                    and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
+                ] or guard_regions
             if issue is None:
                 return rendered, history, guard_applied_any
             next_threshold = ConversionService._next_dropout_threshold(threshold, issue)

--- a/app/application/audio_editor_service.py
+++ b/app/application/audio_editor_service.py
@@ -2063,12 +2063,10 @@ class AudioEditorService:
             }
             history.append(entry)
             if issue and issue.get("bad_regions"):
-                guard_regions = [
-                    (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
-                    for item in (issue.get("bad_regions") or [])
-                    if isinstance(item, dict)
-                    and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
-                ] or guard_regions
+                guard_regions = ConversionService._confirmed_guard_regions(
+                    issue,
+                    guard_regions,
+                )
                 guard_semitones = ConversionService._guard_semitones_for_retry(
                     threshold,
                     issue,

--- a/app/application/conversion_service.py
+++ b/app/application/conversion_service.py
@@ -440,6 +440,7 @@ class ConversionService:
         params: InferenceParams,
         log_file: Path,
         threshold: float | None = None,
+        only_regions: list[tuple[float, float]] | None = None,
     ) -> tuple[Path, bool]:
         """Prepare a selective high-note pitch guard for normal AI covers."""
         if not params.auto_high_pitch_guard or not source.is_file():
@@ -458,8 +459,12 @@ class ConversionService:
                 loudness_source=source,
                 high_threshold=high_threshold,
                 report_path=report_path,
+                regions=only_regions,
             )
         except TypeError:
+            if only_regions:
+                self._log(log_file, "  当前高音保护组件不支持失配区间限制，跳过本次保护以保留原始结果")
+                return source, False
             # Keep compatibility with older in-process tool doubles and
             # installations whose frozen ffmpeg wrapper predates region reports.
             guard_ok = self._ffmpeg.pitch_shift(
@@ -509,6 +514,7 @@ class ConversionService:
         params: InferenceParams,
         log_file: Path,
         threshold: float | None = None,
+        only_regions: list[tuple[float, float]] | None = None,
     ) -> Path:
         if not params.auto_high_pitch_guard:
             return source
@@ -522,8 +528,12 @@ class ConversionService:
                 loudness_source=original,
                 high_threshold=float(threshold or getattr(params, "high_pitch_threshold", 0.0) or self._HIGH_PITCH_THRESHOLD),
                 report_path=destination.with_suffix(".regions.json"),
+                regions=only_regions,
             )
         except TypeError:
+            if only_regions:
+                self._log(log_file, "  当前高音恢复组件不支持失配区间限制，跳过恢复以保留模型输出")
+                return source
             restore_ok = self._ffmpeg.pitch_shift(
                 source,
                 destination,
@@ -960,6 +970,7 @@ class ConversionService:
         history: list[dict[str, Any]] = []
         guard_applied_any = False
         rendered = output
+        guard_regions: list[tuple[float, float]] | None = None
 
         def run_inference(vocals: Path, target: Path) -> None:
             if infer is None:
@@ -1014,6 +1025,12 @@ class ConversionService:
             # old boundary can leave a 700-800 Hz syllable unprotected.
             threshold = self._next_dropout_threshold(threshold, issue)
             params.high_pitch_threshold = threshold
+            guard_regions = [
+                (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
+                for item in (issue.get("bad_regions") or [])
+                if isinstance(item, dict)
+                and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
+            ] or None
             if issue.get("bad_regions") and not params.manual_params_enabled:
                 attempts = max(attempts, self._DROPOUT_RECOVERY_OFFLINE_MAX_ATTEMPTS)
 
@@ -1034,6 +1051,7 @@ class ConversionService:
                 params,
                 log_file,
                 threshold,
+                guard_regions,
             )
             guard_applied_any = guard_applied_any or guard_applied
             run_inference(guarded, raw_target)
@@ -1047,6 +1065,7 @@ class ConversionService:
                     params,
                     log_file,
                     threshold,
+                    guard_regions,
                 )
                 if baseline_first and rendered != output:
                     merged_target = output.with_name(f"{output.stem}_guarded_merged_retry{attempt}.wav")

--- a/app/application/conversion_service.py
+++ b/app/application/conversion_service.py
@@ -110,6 +110,11 @@ class ConversionService:
     _DROPOUT_RECOVERY_MIN_THRESHOLD = 300.0
     _DROPOUT_RECOVERY_MIN_DURATION = 0.12
     _MAX_HIGH_PITCH_GUARD_ROUNDS = 8
+    # Include the attack/release around a confirmed bad syllable. This lets a
+    # high-note phrase be guarded continuously without broadening protection
+    # to unrelated parts of the song.
+    _HIGH_PITCH_GUARD_CONTEXT_SECONDS = 0.90
+    _HIGH_PITCH_GUARD_MERGE_GAP_SECONDS = 1.00
 
     @classmethod
     def _high_pitch_guard_rounds(cls, params: InferenceParams) -> int:
@@ -167,6 +172,41 @@ class ConversionService:
         if source_f0 >= 780.0 or excess >= 80.0:
             return 9
         return cls._HIGH_PITCH_GUARD_SEMITONES
+
+    @classmethod
+    def _confirmed_guard_regions(
+        cls,
+        issue: dict[str, Any] | None,
+        existing: list[tuple[float, float]] | None = None,
+    ) -> list[tuple[float, float]] | None:
+        """Keep confirmed regions and add only local note attack/release context."""
+        raw: list[tuple[float, float]] = list(existing or [])
+        for item in (issue or {}).get("bad_regions") or []:
+            if not isinstance(item, dict):
+                continue
+            try:
+                start = float(item.get("start", 0.0))
+                end = float(item.get("end", 0.0))
+            except (TypeError, ValueError):
+                continue
+            if end > start:
+                raw.append(
+                    (
+                        max(0.0, start - cls._HIGH_PITCH_GUARD_CONTEXT_SECONDS),
+                        end + cls._HIGH_PITCH_GUARD_CONTEXT_SECONDS,
+                    )
+                )
+        if not raw:
+            return None
+        merged: list[tuple[float, float]] = []
+        for start, end in sorted(raw):
+            if end <= start:
+                continue
+            if merged and start <= merged[-1][1] + cls._HIGH_PITCH_GUARD_MERGE_GAP_SECONDS:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        return merged or None
 
     def __init__(
         self,
@@ -855,6 +895,23 @@ class ConversionService:
             if ratios.size >= 8:
                 reference_gain = float(np.median(ratios))
             dropout_ratio = max(0.04, min(1.0, reference_gain * 0.18))
+            # A breathy high note can retain a trackable F0 while losing much
+            # of its vocal support. Detect that local loss relative to the
+            # song's normal gain, but keep the lower boundary well above
+            # ordinary speech so normal quiet phrases are untouched.
+            near_high_floor = max(
+                cls._DROPOUT_RECOVERY_MIN_THRESHOLD,
+                active_threshold - max(180.0, active_threshold * 0.18),
+            )
+            near_high_voice = (
+                (source_rms >= 0.025)
+                & (strength >= 0.35)
+                & (f0 >= near_high_floor)
+            )
+            soft_support_ratio = max(0.12, min(0.68, reference_gain * 0.62))
+            soft_breathy = near_high_voice & (
+                output_rms < source_rms * soft_support_ratio
+            ) & (reference_gain >= 0.35)
             '''
             音调崩溃在失去高音时仍可能保持响亮。
             仅对源的高音帧估计输出F0，以限制内存和误报。
@@ -866,15 +923,29 @@ class ConversionService:
                 high_indices,
             )
             expected_f0 = f0 * (2.0 ** (float(pitch or 0) / 12.0))
-            pitch_collapse = high_voice & (
-                (output_strength < 0.25)
-                | (output_f0 <= 0.0)
-                | (output_f0 < expected_f0 * 0.50)
+            # A zero F0 estimate is not sufficient evidence of a mute: Praat
+            # can lose pitch tracking on a loud, breathy or harmonic-heavy
+            # syllable while the rendered audio remains audible.  Require a
+            # simultaneous local energy drop for the missing-F0 path, while
+            # retaining non-zero but clearly wrong F0 as a real mismatch.
+            pitch_missing = (output_strength < 0.25) | (output_f0 <= 0.0)
+            pitch_missing_energy_limit = np.maximum(
+                0.002,
+                source_rms * max(dropout_ratio * 1.5, 0.12),
+            )
+            pitch_missing_with_mute = pitch_missing & (
+                output_rms < pitch_missing_energy_limit
+            )
+            pitch_wrong = (output_f0 > 0.0) & (
+                (output_f0 < expected_f0 * 0.50)
                 | (output_f0 > expected_f0 * 2.00)
             )
-            bad = high_voice & (
-                output_rms < np.maximum(0.0015, source_rms * dropout_ratio)
-            ) | pitch_collapse
+            pitch_collapse = high_voice & (pitch_missing_with_mute | pitch_wrong)
+            energy_dropout = output_rms < np.maximum(
+                0.0015,
+                source_rms * dropout_ratio,
+            )
+            core_bad = high_voice & (energy_dropout | pitch_collapse)
 
             '''
             高音部分可以在发声帧和静音帧之间交替。
@@ -899,6 +970,15 @@ class ConversionService:
                         begin = None
                 return runs
 
+            # Require a sustained local support loss before treating an
+            # audible, breathy phrase as a dropout. Very brief low-energy
+            # consonants (such as the reported 54s span) stay untouched.
+            soft_min_frames = max(4, round(0.16 / (hop / rate)))
+            soft_breathy_confirmed = np.zeros_like(soft_breathy, dtype=bool)
+            for start, end in contiguous_runs(soft_breathy, soft_min_frames):
+                soft_breathy_confirmed[start:end] = True
+            bad = core_bad | soft_breathy_confirmed
+
             candidates: list[tuple[int, int]] = []
             if high_voice.size >= window_frames:
                 bad_windows = np.lib.stride_tricks.sliding_window_view(bad, window_frames).sum(axis=1)
@@ -909,6 +989,7 @@ class ConversionService:
                 for start in starts:
                     end = int(start + window_frames)
                     candidates.append((int(start), end))
+            candidates.extend(contiguous_runs(soft_breathy_confirmed, min_frames))
             if not candidates:
                 candidates = contiguous_runs(bad, min_frames)
 
@@ -1007,14 +1088,8 @@ class ConversionService:
         infer: Any | None = None,
     ) -> tuple[Path, list[dict[str, Any]], bool]:
         """Run inference and retry only confirmed high-note model dropouts."""
-        threshold = max(self._DROPOUT_RECOVERY_MIN_THRESHOLD, float(params.high_pitch_threshold or 760.0))
-        guard_rounds = self._high_pitch_guard_rounds(params) if allow_recovery else 0
-        attempts = 1 + guard_rounds if allow_recovery and params.auto_high_pitch_guard else 1
         history: list[dict[str, Any]] = []
-        guard_applied_any = False
         rendered = output
-        guard_regions: list[tuple[float, float]] | None = None
-        guard_semitones = self._HIGH_PITCH_GUARD_SEMITONES
 
         def run_inference(vocals: Path, target: Path) -> None:
             if infer is None:
@@ -1028,6 +1103,20 @@ class ConversionService:
                 )
             else:
                 infer(vocals, target)
+
+        if not allow_recovery or not params.auto_high_pitch_guard:
+            # Protection is an opt-in post-inference recovery path.  When it
+            # is disabled, keep the original render path completely untouched
+            # and do not emit a misleading recovery history entry.
+            run_inference(source, output)
+            return output, [], False
+
+        threshold = max(self._DROPOUT_RECOVERY_MIN_THRESHOLD, float(params.high_pitch_threshold or 760.0))
+        guard_rounds = self._high_pitch_guard_rounds(params)
+        attempts = 1 + guard_rounds
+        guard_applied_any = False
+        guard_regions: list[tuple[float, float]] | None = None
+        guard_semitones = self._HIGH_PITCH_GUARD_SEMITONES
 
         '''
         认路径必须与保护功能被禁用时完全一致。
@@ -1069,12 +1158,7 @@ class ConversionService:
             # old boundary can leave a 700-800 Hz syllable unprotected.
             threshold = self._next_dropout_threshold(threshold, issue)
             params.high_pitch_threshold = threshold
-            guard_regions = [
-                (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
-                for item in (issue.get("bad_regions") or [])
-                if isinstance(item, dict)
-                and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
-            ] or None
+            guard_regions = self._confirmed_guard_regions(issue)
             guard_semitones = self._guard_semitones_for_retry(
                 threshold,
                 issue,
@@ -1093,7 +1177,9 @@ class ConversionService:
             best_bad_frames = float(history[0]["issue"].get("bad_frames") or float("inf"))
         for guard_attempt in range(guard_attempts):
             attempt = guard_attempt + 1 if baseline_first else guard_attempt
-            raw_target = output.with_name(f"{output.stem}_dropout_retry{attempt}.wav")
+            raw_target = (
+                output.with_name(f"{output.stem}_dropout_retry{attempt}.wav")
+            )
             guarded_target = output.with_name(f"{output.stem}_high_guarded_retry{attempt}.wav")
             guarded, guard_applied = self._prepare_high_pitch_guard(
                 source,
@@ -1126,11 +1212,7 @@ class ConversionService:
                         rendered,
                         merged_target,
                         restored_target.with_suffix(".regions.json"),
-                        only_regions=[
-                            (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
-                            for item in (history[0].get("issue", {}).get("bad_regions") or [])
-                            if isinstance(item, dict)
-                        ] or None,
+                        only_regions=guard_regions,
                     )
                     if merged != rendered:
                         rendered = merged
@@ -1145,7 +1227,7 @@ class ConversionService:
                     threshold,
                     int(getattr(params, "pitch", 0) or 0),
                 )
-                if allow_recovery
+                if allow_recovery and params.auto_high_pitch_guard
                 else None
             )
             entry: dict[str, Any] = {
@@ -1165,12 +1247,13 @@ class ConversionService:
                     best_bad_frames = candidate_bad_frames
                     best_guard_applied = guard_applied
                 if guard_regions and issue.get("bad_regions"):
+                    prior_guard_regions = guard_regions
                     overlaps_scope = any(
                         float(item.get("end", 0.0)) > start
                         and float(item.get("start", 0.0)) < end
                         for item in (issue.get("bad_regions") or [])
                         if isinstance(item, dict)
-                        for start, end in guard_regions
+                        for start, end in prior_guard_regions
                     )
                     if not overlaps_scope:
                         self._log(
@@ -1178,6 +1261,10 @@ class ConversionService:
                             "  新检测到的哑音位于本轮保护范围外，停止继续降低阈值并保留当前最佳结果",
                         )
                         return best_render, history, best_guard_applied
+                    guard_regions = self._confirmed_guard_regions(
+                        issue,
+                        prior_guard_regions,
+                    )
             next_threshold = self._next_dropout_threshold(threshold, issue)
             entry["next_threshold"] = next_threshold
             if next_threshold >= threshold - 10.0 or guard_attempt >= guard_attempts - 1:

--- a/app/application/conversion_service.py
+++ b/app/application/conversion_service.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import threading
 import traceback
 import wave
+import json
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -101,6 +103,32 @@ def default_steps_ai_enhancement() -> list[dict[str, Any]]:
 class ConversionService:
     _HIGH_PITCH_THRESHOLD = 800.0
     _HIGH_PITCH_GUARD_SEMITONES = 7
+    _DROPOUT_RECOVERY_MAX_ATTEMPTS = 4
+    # Offline full-track recovery can afford one extra pass after a real
+    # regional detector result; realtime/editor keep the lower shared limit.
+    _DROPOUT_RECOVERY_OFFLINE_MAX_ATTEMPTS = 5
+    _DROPOUT_RECOVERY_MIN_THRESHOLD = 300.0
+    _DROPOUT_RECOVERY_MIN_DURATION = 0.12
+    _MAX_HIGH_PITCH_GUARD_ROUNDS = 8
+
+    @classmethod
+    def _high_pitch_guard_rounds(cls, params: InferenceParams) -> int:
+        """Return the user-selected guarded retry count.
+
+        The ordinary workflow deliberately ignores the stored advanced value
+        and keeps the established three retry rounds. This prevents a preset
+        saved with full parameters from changing default-mode rendering.
+        """
+        if not bool(getattr(params, "auto_high_pitch_guard", True)):
+            return 0
+        default_rounds = max(0, cls._DROPOUT_RECOVERY_MAX_ATTEMPTS - 1)
+        if not bool(getattr(params, "manual_params_enabled", False)):
+            return default_rounds
+        try:
+            configured = int(getattr(params, "high_pitch_guard_rounds", default_rounds))
+        except (TypeError, ValueError):
+            configured = default_rounds
+        return max(0, min(cls._MAX_HIGH_PITCH_GUARD_ROUNDS, configured))
     def __init__(
         self,
         repo: ListRepository,
@@ -196,8 +224,7 @@ class ConversionService:
             "loudness_envelope": strength("loudness_envelope", 0.58),
         }
         if work.get("high_pitch_guard_applied"):
-            # The guard already restores high harmonics. Tone-shaping controls
-            # stay deliberately lighter so the protected consonants remain natural.
+            # 防护装置已恢复高谐波。音色塑造控制部分被有意调至更轻，以保持受保护的辅音自然清晰。
             controls["timbre_focus"] *= 0.68
             controls["ai_eq"] *= 0.78
             controls["ai_compressor"] *= 0.82
@@ -293,12 +320,25 @@ class ConversionService:
         if not params.auto_high_pitch_guard:
             self._log(log_file, "  高音保护已关闭：保留手动 F0、滤波半径和辅音保护参数")
             return
+        if not params.manual_params_enabled:
+            # Default mode must keep the engine's established F0/protection
+            # defaults.  Advanced adaptation is opt-in through full parameters;
+            # verified model dropouts are handled separately by retry logic.
+            self._log(log_file, "  普通模式：保留默认 F0、滤波半径和辅音保护参数")
+            return
         high_pitch = bool(profile.get("high_pitch"))
         high_frequency = bool(profile.get("high_frequency"))
-        recommended = max(
+        source_recommended = max(
             1100.0,
             min(1800.0, float(profile.get("recommended_f0_max") or 1100.0)),
         )
+        model_limit = float(getattr(params, "high_pitch_threshold", 0.0) or 0.0)
+        if model_limit > 0:
+            # A declared model ceiling is authoritative, even for models whose
+            # usable range is below the generic 600 Hz safety floor.
+            recommended = max(300.0, min(source_recommended, model_limit))
+        else:
+            recommended = max(600.0, source_recommended)
         setattr(params, "adaptive_f0_max", recommended)
         normalized_framework = config.modelhub_normalize_framework(framework)
         current_method = str(params.f0_method or "rmvpe").lower()
@@ -331,32 +371,133 @@ class ConversionService:
             f"高音={'是' if high_pitch else '否'} / 高频={'是' if high_frequency else '否'}",
         )
 
+    @staticmethod
+    def _model_high_pitch_threshold(
+        params: InferenceParams,
+        model: dict[str, Any] | None,
+        framework: str,
+    ) -> float:
+        """Resolve the guard boundary from the selected model, not one global constant.
+
+        Imported model metadata wins, then common f0_max config keys, followed by
+        conservative framework-specific defaults. A user supplied parameter is
+        treated as an explicit override (0 means automatic).
+        """
+        explicit = float(getattr(params, "high_pitch_threshold", 0.0) or 0.0)
+        if explicit > 0:
+            return max(300.0, min(2000.0, explicit))
+        if not bool(getattr(params, "manual_params_enabled", False)):
+            # Without a model-declared usable range, preserve the legacy default
+            # path.  Dropout recovery can lower this boundary only after it has
+            # verified a real voiced model collapse.
+            return ConversionService._HIGH_PITCH_THRESHOLD
+        model = model or {}
+        metadata = model.get("metadata") or model.get("model_metadata") or {}
+        profile = metadata.get("inference_profile") if isinstance(metadata, dict) else None
+        candidates: list[Any] = []
+        if isinstance(profile, dict):
+            candidates.extend([profile.get("high_pitch_threshold"), profile.get("f0_max_hz"), profile.get("f0_max")])
+        if isinstance(metadata, dict):
+            candidates.extend([metadata.get("high_pitch_threshold"), metadata.get("f0_max_hz"), metadata.get("f0_max")])
+        config_path = str(model.get("main_config_path") or "")
+        if config_path:
+            try:
+                raw = Path(config_path).read_text(encoding="utf-8")
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        def visit(value: Any) -> None:
+                            if isinstance(value, dict):
+                                for key, child in value.items():
+                                    if str(key).lower() in {"f0_max", "f0_max_hz", "max_f0"}:
+                                        candidates.append(child)
+                                    visit(child)
+                            elif isinstance(value, list):
+                                for child in value:
+                                    visit(child)
+                        visit(parsed)
+                except (TypeError, ValueError):
+                    for key in ("f0_max", "f0_max_hz", "max_f0"):
+                        match = re.search(rf"(?:^|\n)\s*{key}\s*:\s*([0-9]+(?:\.[0-9]+)?)", raw, re.I)
+                        if match:
+                            candidates.append(match.group(1))
+            except OSError:
+                pass
+        for value in candidates:
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                continue
+            if 300.0 <= number <= 2000.0:
+                return number
+        defaults = {"rvc": 760.0, "seed-vc": 980.0, "ddsp-svc": 1040.0, "so-vits-svc": 1120.0}
+        return defaults.get(config.modelhub_normalize_framework(framework), 1000.0)
+
     def _prepare_high_pitch_guard(
         self,
         source: Path,
         destination: Path,
         params: InferenceParams,
         log_file: Path,
+        threshold: float | None = None,
     ) -> tuple[Path, bool]:
         """Prepare a selective high-note pitch guard for normal AI covers."""
         if not params.auto_high_pitch_guard or not source.is_file():
             return source, False
         peak_f0 = self._estimate_peak_f0(source)
-        if peak_f0 < self._HIGH_PITCH_THRESHOLD:
+        high_threshold = float(threshold or getattr(params, "high_pitch_threshold", 0.0) or self._HIGH_PITCH_THRESHOLD)
+        if peak_f0 < high_threshold:
             return source, False
-        if not self._ffmpeg.pitch_shift(
-            source,
-            destination,
-            -self._HIGH_PITCH_GUARD_SEMITONES,
-            mask_source=source,
-            loudness_source=source,
-            high_threshold=self._HIGH_PITCH_THRESHOLD,
-        ):
+        report_path = destination.with_suffix(".regions.json")
+        try:
+            guard_ok = self._ffmpeg.pitch_shift(
+                source,
+                destination,
+                -self._HIGH_PITCH_GUARD_SEMITONES,
+                mask_source=source,
+                loudness_source=source,
+                high_threshold=high_threshold,
+                report_path=report_path,
+            )
+        except TypeError:
+            # Keep compatibility with older in-process tool doubles and
+            # installations whose frozen ffmpeg wrapper predates region reports.
+            guard_ok = self._ffmpeg.pitch_shift(
+                source,
+                destination,
+                -self._HIGH_PITCH_GUARD_SEMITONES,
+                mask_source=source,
+                loudness_source=source,
+                high_threshold=high_threshold,
+            )
+        if not guard_ok:
             self._log(log_file, f"  高音保护降调失败，沿用原始推理输入（峰值 F0={peak_f0:.1f}Hz）")
+            return source, False
+        region_count = 0
+        processed_seconds = 0.0
+        region_preview = ""
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            region_count = int(report.get("region_count") or 0)
+            processed_seconds = float(report.get("processed_seconds") or 0.0)
+            regions = report.get("regions") or []
+            region_preview = ", ".join(
+                f"{float(item['start']):.2f}-{float(item['end']):.2f}s"
+                for item in regions[:6]
+                if isinstance(item, dict)
+            )
+            if len(regions) > 6:
+                region_preview += ", ..."
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            pass
+        if region_count <= 0:
+            self._log(log_file, "  高音保护未找到稳定高音区：整轨原样保留")
             return source, False
         self._log(
             log_file,
-            f"  高音保护已启用：仅对高音区域保共振峰降调 -{self._HIGH_PITCH_GUARD_SEMITONES} 半音（峰值 F0={peak_f0:.1f}Hz）",
+            f"  高音保护已启用：仅处理 {region_count} 个高音区，共 {processed_seconds:.2f}s "
+            f"（阈值 {high_threshold:.0f}Hz，降调 -{self._HIGH_PITCH_GUARD_SEMITONES} 半音；"
+            f"区间 {region_preview}）",
         )
         return destination, True
 
@@ -367,27 +508,650 @@ class ConversionService:
         original: Path,
         params: InferenceParams,
         log_file: Path,
+        threshold: float | None = None,
     ) -> Path:
         if not params.auto_high_pitch_guard:
             return source
         restored = destination
-        if self._ffmpeg.pitch_shift(
-            source,
-            destination,
-            self._HIGH_PITCH_GUARD_SEMITONES,
-            mask_source=original,
-            loudness_source=original,
-            high_threshold=self._HIGH_PITCH_THRESHOLD,
-        ):
-            self._log(log_file, "  高音保护完成：翻唱后仅对高音区域升回原调并补偿响度")
+        try:
+            restore_ok = self._ffmpeg.pitch_shift(
+                source,
+                destination,
+                self._HIGH_PITCH_GUARD_SEMITONES,
+                mask_source=original,
+                loudness_source=original,
+                high_threshold=float(threshold or getattr(params, "high_pitch_threshold", 0.0) or self._HIGH_PITCH_THRESHOLD),
+                report_path=destination.with_suffix(".regions.json"),
+            )
+        except TypeError:
+            restore_ok = self._ffmpeg.pitch_shift(
+                source,
+                destination,
+                self._HIGH_PITCH_GUARD_SEMITONES,
+                mask_source=original,
+                loudness_source=original,
+                high_threshold=float(threshold or getattr(params, "high_pitch_threshold", 0.0) or self._HIGH_PITCH_THRESHOLD),
+            )
+        if restore_ok:
+            self._log(log_file, "  高音保护完成：仅对记录的高音区域升回原调并补偿响度")
             return restored
         self._log(log_file, "  高音保护升调失败，沿用模型输出")
         return source
 
     @staticmethod
+    def _merge_guarded_regions(
+        baseline: Path,
+        guarded: Path,
+        destination: Path,
+        report_path: Path,
+        only_regions: list[tuple[float, float]] | None = None,
+    ) -> Path:
+        """ 
+        保留基础渲染，除已确认失败的高音区。
+        """
+        try:
+            import numpy as np
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            regions = report.get("regions") if isinstance(report, dict) else None
+            if not isinstance(regions, list) or not regions:
+                return guarded
+            selected_regions: list[tuple[float, float]] = []
+            for item in regions:
+                if not isinstance(item, dict):
+                    continue
+                start = float(item.get("start", 0.0))
+                end = float(item.get("end", start))
+                if end <= start:
+                    continue
+                if only_regions:
+                    overlaps = [
+                        (max(start, bad_start), min(end, bad_end))
+                        for bad_start, bad_end in only_regions
+                        if end > bad_start and start < bad_end
+                    ]
+                    selected_regions.extend(
+                        (left, right) for left, right in overlaps if right > left
+                    )
+                else:
+                    selected_regions.append((start, end))
+            if not selected_regions:
+                return baseline
+            with wave.open(str(baseline), "rb") as base_wave:
+                base_params = base_wave.getparams()
+                base_raw = base_wave.readframes(base_wave.getnframes())
+            with wave.open(str(guarded), "rb") as guarded_wave:
+                guarded_params = guarded_wave.getparams()
+                guarded_raw = guarded_wave.readframes(guarded_wave.getnframes())
+            if (
+                base_params.sampwidth != 2
+                or guarded_params.sampwidth != 2
+                or base_params.nchannels != guarded_params.nchannels
+                or base_params.framerate != guarded_params.framerate
+            ):
+                return guarded
+            channels = max(1, int(base_params.nchannels))
+            base_values = np.frombuffer(base_raw, dtype="<i2").copy()
+            guarded_values = np.frombuffer(guarded_raw, dtype="<i2").copy()
+            base_frames = base_values.size // channels
+            guarded_frames = guarded_values.size // channels
+            if base_frames <= 0 or guarded_frames <= 0:
+                return guarded
+            count = min(base_frames, guarded_frames)
+            base_values = base_values[: count * channels].reshape(count, channels).astype(np.float64)
+            guarded_values = guarded_values[: count * channels].reshape(count, channels).astype(np.float64)
+            rate = float(base_params.framerate)
+            mask = np.zeros(count, dtype=np.float64)
+            fade = max(1, int(round(rate * 0.08)))
+            duration = count / rate
+            for raw_start, raw_end in selected_regions:
+                start = max(0.0, min(duration, raw_start))
+                end = max(start, min(duration, raw_end))
+                left = max(0, min(count, int(round(start * rate))))
+                right = max(left, min(count, int(round(end * rate))))
+                if right <= left:
+                    continue
+                mask[left:right] = 1.0
+                left_edge = max(0, left - fade)
+                if left > left_edge:
+                    phase = np.linspace(0.0, np.pi / 2.0, left - left_edge, endpoint=False)
+                    mask[left_edge:left] = np.maximum(mask[left_edge:left], np.sin(phase) ** 2)
+                right_edge = min(count, right + fade)
+                if right_edge > right:
+                    phase = np.linspace(np.pi / 2.0, 0.0, right_edge - right, endpoint=False)
+                    mask[right:right_edge] = np.maximum(mask[right:right_edge], np.sin(phase) ** 2)
+            if not np.any(mask > 0.0):
+                return guarded
+            merged = base_values * (1.0 - mask[:, None]) + guarded_values * mask[:, None]
+            merged = np.clip(np.rint(merged), -32768, 32767).astype("<i2")
+            if guarded_frames < base_frames:
+                # A truncated retry must never truncate the user's baseline.
+                merged = np.concatenate(
+                    (merged, np.frombuffer(base_raw, dtype="<i2")[count * channels : base_frames * channels].reshape(-1, channels)),
+                    axis=0,
+                )
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with wave.open(str(destination), "wb") as output_wave:
+                output_wave.setparams(base_params)
+                output_wave.writeframes(merged.reshape(-1).tobytes())
+            return destination if destination.exists() else guarded
+        except (OSError, TypeError, ValueError, wave.Error, json.JSONDecodeError):
+            return guarded
+
+    @staticmethod
+    def _read_mono_audio(source: Path, target_rate: int = 16000):
+        """读取 PCM WAV 为单声道浮点数组，供模型输出质量探针使用。"""
+        import numpy as np
+
+        with wave.open(str(source), "rb") as handle:
+            rate = int(handle.getframerate() or target_rate)
+            channels = max(1, int(handle.getnchannels() or 1))
+            width = int(handle.getsampwidth() or 2)
+            raw = handle.readframes(handle.getnframes())
+        if not raw or rate <= 0:
+            return np.zeros(0, dtype=np.float32), target_rate
+        if width == 1:
+            audio = (np.frombuffer(raw, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+        elif width == 2:
+            audio = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
+        elif width == 4:
+            audio = np.frombuffer(raw, dtype="<i4").astype(np.float32) / 2147483648.0
+        else:
+            return np.zeros(0, dtype=np.float32), target_rate
+        usable = (audio.size // channels) * channels
+        if usable <= 0:
+            return np.zeros(0, dtype=np.float32), target_rate
+        audio = audio[:usable].reshape(-1, channels).mean(axis=1)
+        if rate == target_rate:
+            return audio.astype(np.float32, copy=False), target_rate
+        count = max(1, round(audio.size * target_rate / rate))
+        positions = np.linspace(0, audio.size - 1, count)
+        return np.interp(positions, np.arange(audio.size), audio).astype(np.float32), target_rate
+
+    @classmethod
+    def _detect_model_dropout(
+        cls,
+        source: Path,
+        output: Path,
+        threshold: float,
+        pitch: int = 0,
+    ) -> dict[str, Any] | None:
+        """当可用时，优先使用源侧F0边车，因为它传递给SVC的曲线与模型支持的曲线相同。除了输出被静音外，
+            还应检测到一个高音源音符，其输出仍然具有能量，但失去了预期的基频；这是音符塌陷为低次谐波时常见的“哑音”故障模式。
+        """
+        try:
+            import numpy as np
+
+            source_audio, rate = cls._read_mono_audio(source)
+            output_audio, output_rate = cls._read_mono_audio(output)
+            if source_audio.size < 1024 or output_audio.size < 1024 or rate != output_rate:
+                return None
+            size = min(source_audio.size, output_audio.size)
+            source_audio = source_audio[:size]
+            output_audio = output_audio[:size]
+            frame = max(512, int(rate * 0.04))
+            hop = max(256, int(rate * 0.02))
+            if size < frame:
+                return None
+            min_lag = max(2, int(rate / 2000.0))
+            max_lag = min(frame - 2, int(rate / 60.0))
+            if max_lag <= min_lag + 2:
+                return None
+            source_frames = np.lib.stride_tricks.sliding_window_view(source_audio, frame)[::hop]
+            output_frames = np.lib.stride_tricks.sliding_window_view(output_audio, frame)[::hop]
+            if source_frames.size == 0 or output_frames.size == 0:
+                return None
+            source_frames = source_frames[: len(output_frames)]
+            output_frames = output_frames[: len(source_frames)]
+            source_frames = source_frames - source_frames.mean(axis=1, keepdims=True)
+            output_frames = output_frames - output_frames.mean(axis=1, keepdims=True)
+            source_rms = np.sqrt(np.mean(source_frames * source_frames, axis=1))
+            output_rms = np.sqrt(np.mean(output_frames * output_frames, axis=1))
+            def estimate_pitch(
+                frames: object,
+                rms: object,
+                indices: object,
+            ) -> tuple[object, object]:
+                pitch_values = np.zeros(len(rms), dtype=np.float32)
+                pitch_strength = np.zeros(len(rms), dtype=np.float32)
+                selected = np.asarray(indices, dtype=np.int64)
+                selected = selected[np.asarray(rms)[selected] >= 0.008]
+                if selected.size == 0:
+                    return pitch_values, pitch_strength
+                valid_frames = np.asarray(frames)[selected]
+                fft_size = 1 << max(10, (2 * frame - 1).bit_length())
+                spectrum = np.fft.rfft(valid_frames, n=fft_size, axis=1)
+                autocorr = np.fft.irfft(spectrum * np.conj(spectrum), n=fft_size, axis=1)[:, : frame]
+                bases = autocorr[:, 0]
+                lag_window = autocorr[:, min_lag : max_lag + 1]
+                lag_offsets = np.argmax(lag_window, axis=1)
+                lags = lag_offsets + min_lag
+                best = lag_window[np.arange(lag_window.shape[0]), lag_offsets]
+                valid_base = bases > 0.0
+                strengths = np.zeros_like(best, dtype=np.float32)
+                strengths[valid_base] = best[valid_base] / bases[valid_base]
+                f0_values = np.zeros_like(strengths, dtype=np.float32)
+                reliable = (strengths >= 0.35) & (lags > 0)
+                f0_values[reliable] = rate / lags[reliable].astype(np.float32)
+                pitch_values[selected] = f0_values
+                pitch_strength[selected] = strengths
+                return pitch_values, pitch_strength
+
+            all_indices = np.arange(source_frames.shape[0], dtype=np.int64)
+            f0, strength = estimate_pitch(source_frames, source_rms, all_indices)
+
+            # F0 extraction already ran immediately before SVC and is more
+            # reliable than a second lightweight autocorrelation pass on loud
+            # high harmonics.  Interpolate its time-aligned values to detector
+            # frames when this is one of the standard inference inputs.
+            if source.name.lower() in {"infer_input.wav", "vocals_repaired.wav"}:
+                sidecar = source.with_name("f0.npy")
+                try:
+                    if sidecar.stat().st_mtime >= source.stat().st_mtime - 120.0:
+                        curve = np.asarray(np.load(str(sidecar), allow_pickle=False)).reshape(-1)
+                        finite = np.isfinite(curve) & (curve > 0.0)
+                        valid_curve = np.flatnonzero(finite)
+                        if valid_curve.size >= 4:
+                            curve_times = np.linspace(
+                                0.0,
+                                size / float(rate),
+                                curve.size,
+                            )
+                            frame_times = (
+                                np.arange(f0.size, dtype=np.float64) * hop
+                                + frame * 0.5
+                            ) / float(rate)
+                            sidecar_f0 = np.interp(
+                                frame_times,
+                                curve_times[valid_curve],
+                                curve[valid_curve],
+                            )
+                            sidecar_valid = (
+                                (frame_times >= curve_times[valid_curve[0]])
+                                & (frame_times <= curve_times[valid_curve[-1]])
+                            )
+                            f0[sidecar_valid] = sidecar_f0[sidecar_valid]
+                            strength[sidecar_valid] = np.maximum(
+                                strength[sidecar_valid],
+                                0.8,
+                            )
+                except (OSError, ValueError, TypeError):
+                    pass
+
+            # 也略微低于活跃防护边界。一个短音节可以刚好位于边界之下，但仍属于需要更低重试阈值的模型不匹配音符。
+            active_threshold = float(threshold or 760.0)
+            high_floor = max(
+                cls._DROPOUT_RECOVERY_MIN_THRESHOLD,
+                active_threshold - max(70.0, active_threshold * 0.08),
+            )
+            high_voice = (
+                (source_rms >= 0.012)
+                & (strength >= 0.35)
+                & (f0 >= high_floor)
+            )
+
+            '''
+            型渲染的增益不一定与分离的语音部分具有相同的全局增益。从发声帧估计出的增益，
+            使得整体更安静（但其他方面仍然有效）的渲染结果不会被误认为是局部静音，
+            并通过一个有害的保护重试机制发送。对于本地静音并经由破坏性守卫发送的重试
+            '''
+            voiced = (source_rms >= 0.008) & (strength >= 0.35)
+            ratios = output_rms[voiced] / np.maximum(source_rms[voiced], 1e-5)
+            ratios = ratios[np.isfinite(ratios) & (ratios > 0.0)]
+            reference_gain = 1.0
+            if ratios.size >= 8:
+                reference_gain = float(np.median(ratios))
+            dropout_ratio = max(0.04, min(1.0, reference_gain * 0.18))
+            '''
+            音调崩溃在失去高音时仍可能保持响亮。
+            仅对源的高音帧估计输出F0，以限制内存和误报。
+            '''
+            high_indices = np.flatnonzero(high_voice)
+            output_f0, output_strength = estimate_pitch(
+                output_frames,
+                output_rms,
+                high_indices,
+            )
+            expected_f0 = f0 * (2.0 ** (float(pitch or 0) / 12.0))
+            pitch_collapse = high_voice & (
+                (output_strength < 0.25)
+                | (output_f0 <= 0.0)
+                | (output_f0 < expected_f0 * 0.50)
+                | (output_f0 > expected_f0 * 2.00)
+            )
+            bad = high_voice & (
+                output_rms < np.maximum(0.0015, source_rms * dropout_ratio)
+            ) | pitch_collapse
+
+            '''
+            高音部分可以在发声帧和静音帧之间交替。
+            使用短滑动窗口以及连续的运行，以便这些短暂的中断仍能触发恢复，
+            而无需将单个帧视为失败。
+            '''
+            min_frames = max(4, round(cls._DROPOUT_RECOVERY_MIN_DURATION / (hop / rate)))
+            window_frames = max(min_frames, round(0.24 / (hop / rate)))
+
+            def contiguous_runs(mask: object, minimum: int) -> list[tuple[int, int]]:
+                values = np.asarray(mask, dtype=bool)
+                runs: list[tuple[int, int]] = []
+                begin: int | None = None
+                for index, value in enumerate(
+                    np.concatenate((values, np.array([False], dtype=bool)))
+                ):
+                    if value and begin is None:
+                        begin = index
+                    elif not value and begin is not None:
+                        if index - begin >= minimum:
+                            runs.append((begin, index))
+                        begin = None
+                return runs
+
+            candidates: list[tuple[int, int]] = []
+            if high_voice.size >= window_frames:
+                bad_windows = np.lib.stride_tricks.sliding_window_view(bad, window_frames).sum(axis=1)
+                voice_windows = np.lib.stride_tricks.sliding_window_view(high_voice, window_frames).sum(axis=1)
+                enough_voice = voice_windows >= min_frames
+                enough_bad = bad_windows >= np.maximum(2, np.ceil(voice_windows * 0.25))
+                starts = np.flatnonzero(enough_voice & enough_bad)
+                for start in starts:
+                    end = int(start + window_frames)
+                    candidates.append((int(start), end))
+            if not candidates:
+                candidates = contiguous_runs(bad, min_frames)
+
+            '''
+           单个脱落音节通常比常规的120毫秒确认窗口更短。
+           仅在接近无声的情况下接受此快速路径，并要求至少两个相邻的分析帧，
+           以避免正常辅音间隙和颤音导致重试。
+            '''
+            short_ratio = max(0.025, min(0.12, reference_gain * 0.08))
+            short_mute = high_voice & (
+                output_rms < np.maximum(0.0008, source_rms * short_ratio)
+            )
+            short_min_frames = max(2, round(0.04 / (hop / rate)))
+            short_candidates = contiguous_runs(short_mute, short_min_frames)
+            candidates.extend(short_candidates)
+            if not candidates:
+                return None
+
+            '''
+           保留实际失败的帧用于区域合并。滑动窗口仅作为确认证据；使用其完整宽度会不必要地替换掉健康的相邻音节。
+            '''
+            confirmed_bad = np.zeros_like(bad, dtype=bool)
+            for candidate_start, candidate_end in candidates:
+                if (candidate_start, candidate_end) in short_candidates:
+                    confirmed_bad[candidate_start:candidate_end] |= short_mute[
+                        candidate_start:candidate_end
+                    ]
+                else:
+                    confirmed_bad[candidate_start:candidate_end] |= bad[
+                        candidate_start:candidate_end
+                    ]
+            confirmed_runs = contiguous_runs(confirmed_bad, 1)
+            if not confirmed_runs:
+                return None
+            bad_regions: list[dict[str, float]] = []
+            for candidate_start, candidate_end in confirmed_runs:
+                region_start = max(0.0, candidate_start * hop / rate)
+                region_end = min(
+                    size / float(rate),
+                    candidate_end * hop / rate + frame / rate,
+                )
+                if region_end <= region_start:
+                    continue
+                if bad_regions and region_start <= bad_regions[-1]["end"] + 0.12:
+                    bad_regions[-1]["end"] = max(bad_regions[-1]["end"], region_end)
+                else:
+                    bad_regions.append({"start": region_start, "end": region_end})
+            begin, end = confirmed_runs[0]
+            f0_values = f0[begin:end]
+            f0_values = f0_values[f0_values > 0]
+            if f0_values.size == 0:
+                return None
+            output_f0_values = output_f0[begin:end]
+            output_f0_values = output_f0_values[output_f0_values > 0]
+            return {
+                "start": round(begin * hop / rate, 3),
+                "end": round(end * hop / rate + frame / rate, 3),
+                "source_f0_hz": round(float(np.median(f0_values)), 1),
+                "source_rms": round(float(np.median(source_rms[begin:end])), 5),
+                "output_rms": round(float(np.median(output_rms[begin:end])), 5),
+                "output_f0_hz": round(
+                    float(np.median(output_f0_values))
+                    if output_f0_values.size
+                    else 0.0,
+                    1,
+                ),
+                "bad_frames": float(np.sum(confirmed_bad)),
+                "high_frames": float(np.sum(high_voice)),
+                "bad_regions": bad_regions,
+                "duration": round((end - begin) * hop / rate, 3),
+            }
+        except (OSError, ValueError, wave.Error, ImportError):
+            return None
+
+    @classmethod
+    def _next_dropout_threshold(cls, current: float, issue: dict[str, float]) -> float:
+        """Place the next guard boundary just below the failing note."""
+        current = max(cls._DROPOUT_RECOVERY_MIN_THRESHOLD, float(current or 760.0))
+        f0 = float(issue.get("source_f0_hz") or 0.0)
+        step = max(35.0, current * 0.08)
+        target = min(current - step, f0 - 20.0) if f0 > 0 else current - step
+        target = max(cls._DROPOUT_RECOVERY_MIN_THRESHOLD, target)
+        return round(target / 10.0) * 10.0
+
+    def _infer_with_dropout_recovery(
+        self,
+        *,
+        engine: Any,
+        model: dict[str, Any],
+        source: Path,
+        output: Path,
+        params: InferenceParams,
+        duration: float,
+        log_file: Path,
+        allow_recovery: bool,
+        infer: Any | None = None,
+    ) -> tuple[Path, list[dict[str, Any]], bool]:
+        """Run inference and retry only confirmed high-note model dropouts."""
+        threshold = max(self._DROPOUT_RECOVERY_MIN_THRESHOLD, float(params.high_pitch_threshold or 760.0))
+        guard_rounds = self._high_pitch_guard_rounds(params) if allow_recovery else 0
+        attempts = 1 + guard_rounds if allow_recovery and params.auto_high_pitch_guard else 1
+        history: list[dict[str, Any]] = []
+        guard_applied_any = False
+        rendered = output
+
+        def run_inference(vocals: Path, target: Path) -> None:
+            if infer is None:
+                engine.infer(
+                    model=model,
+                    vocals=vocals,
+                    out_path=target,
+                    params=params,
+                    duration=duration,
+                    log_file=log_file,
+                )
+            else:
+                infer(vocals, target)
+
+        '''
+        认路径必须与保护功能被禁用时完全一致。
+        受保护的源代码会改变模型所看到的条件，
+        因此将其应用于每首歌曲可能会降低整个渲染质量，
+        即使不存在断音情况。请先运行普通输入，
+        仅在确认高音部分已正确处理后，再支付防护/重试的代价。
+        '''
+        baseline_first = bool(allow_recovery and params.auto_high_pitch_guard)
+        if baseline_first:
+            run_inference(source, output)
+            rendered = output
+            issue = self._detect_model_dropout(
+                source,
+                rendered,
+                threshold,
+                int(getattr(params, "pitch", 0) or 0),
+            )
+            history.append(
+                {
+                    "attempt": 1,
+                    "threshold": round(threshold, 1),
+                    "issue": issue,
+                    "guard_applied": False,
+                    "input": "original",
+                }
+            )
+            if issue is None:
+                return rendered, history, False
+            self._log(
+                log_file,
+                "  首次原始推理检测到模型失配哑音，启动局部高音保护重试："
+                f"{issue['start']:.2f}-{issue['end']:.2f}s / "
+                f"源 F0 {issue['source_f0_hz']:.0f}Hz / "
+                f"输出 F0 {float(issue.get('output_f0_hz') or 0.0):.0f}Hz",
+            )
+            # The first confirmed failing note is already enough to lower the
+            # next guard boundary.  Starting the first guarded retry at the
+            # old boundary can leave a 700-800 Hz syllable unprotected.
+            threshold = self._next_dropout_threshold(threshold, issue)
+            params.high_pitch_threshold = threshold
+            if issue.get("bad_regions") and not params.manual_params_enabled:
+                attempts = max(attempts, self._DROPOUT_RECOVERY_OFFLINE_MAX_ATTEMPTS)
+
+        guard_attempts = max(0, attempts - 1) if baseline_first else attempts
+        fallback = output if baseline_first else rendered
+        best_render = fallback
+        best_bad_frames = float("inf")
+        best_guard_applied = False
+        if baseline_first and history and history[0].get("issue"):
+            best_bad_frames = float(history[0]["issue"].get("bad_frames") or float("inf"))
+        for guard_attempt in range(guard_attempts):
+            attempt = guard_attempt + 1 if baseline_first else guard_attempt
+            raw_target = output.with_name(f"{output.stem}_dropout_retry{attempt}.wav")
+            guarded_target = output.with_name(f"{output.stem}_high_guarded_retry{attempt}.wav")
+            guarded, guard_applied = self._prepare_high_pitch_guard(
+                source,
+                guarded_target,
+                params,
+                log_file,
+                threshold,
+            )
+            guard_applied_any = guard_applied_any or guard_applied
+            run_inference(guarded, raw_target)
+            rendered = raw_target
+            if guard_applied:
+                restored_target = output.with_name(f"{output.stem}_restored_retry{attempt}.wav")
+                rendered = self._restore_high_pitch_guard(
+                    raw_target,
+                    restored_target,
+                    source,
+                    params,
+                    log_file,
+                    threshold,
+                )
+                if baseline_first and rendered != output:
+                    merged_target = output.with_name(f"{output.stem}_guarded_merged_retry{attempt}.wav")
+                    merged = self._merge_guarded_regions(
+                        output,
+                        rendered,
+                        merged_target,
+                        restored_target.with_suffix(".regions.json"),
+                        only_regions=[
+                            (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
+                            for item in (history[0].get("issue", {}).get("bad_regions") or [])
+                            if isinstance(item, dict)
+                        ] or None,
+                    )
+                    if merged != rendered:
+                        rendered = merged
+                        self._log(
+                            log_file,
+                            "  高音保护结果已按高音区合并：非高音区域沿用首次原始推理结果",
+                        )
+            issue = (
+                self._detect_model_dropout(
+                    source,
+                    rendered,
+                    threshold,
+                    int(getattr(params, "pitch", 0) or 0),
+                )
+                if allow_recovery
+                else None
+            )
+            entry: dict[str, Any] = {
+                "attempt": len(history) + 1,
+                "threshold": round(threshold, 1),
+                "issue": issue,
+                "guard_applied": guard_applied,
+                "input": "high_guarded" if guard_applied else "original",
+            }
+            history.append(entry)
+            if issue is None:
+                return rendered, history, guard_applied_any
+            if baseline_first:
+                candidate_bad_frames = float(issue.get("bad_frames") or float("inf"))
+                if candidate_bad_frames < best_bad_frames:
+                    best_render = rendered
+                    best_bad_frames = candidate_bad_frames
+                    best_guard_applied = guard_applied
+            next_threshold = self._next_dropout_threshold(threshold, issue)
+            entry["next_threshold"] = next_threshold
+            if next_threshold >= threshold - 10.0 or guard_attempt >= guard_attempts - 1:
+                if baseline_first:
+                    if best_render != fallback:
+                        self._log(
+                            log_file,
+                            "  高音保护未完全消除哑音，采用哑音帧更少的保护结果："
+                            f"{best_bad_frames:.0f} 帧（首次 {float(history[0]['issue'].get('bad_frames') or 0.0):.0f} 帧）",
+                        )
+                        return best_render, history, best_guard_applied
+                    self._log(
+                        log_file,
+                        "  高音保护重试仍检测到模型失配哑音，回退到首次原始推理结果："
+                        f"{issue['start']:.2f}-{issue['end']:.2f}s / "
+                        f"源 F0 {issue['source_f0_hz']:.0f}Hz / "
+                        f"输出 F0 {float(issue.get('output_f0_hz') or 0.0):.0f}Hz",
+                    )
+                    return fallback, history, False
+                self._log(
+                    log_file,
+                    "  模型失配哑音仍未消除："
+                    f"{issue['start']:.2f}-{issue['end']:.2f}s / "
+                    f"源 F0 {issue['source_f0_hz']:.0f}Hz，保留最后一次推理结果",
+                )
+                return rendered, history, guard_applied_any
+            self._log(
+                log_file,
+                "  检测到模型失配哑音："
+                f"{issue['start']:.2f}-{issue['end']:.2f}s / "
+                f"源 F0 {issue['source_f0_hz']:.0f}Hz / "
+                f"输出 F0 {float(issue.get('output_f0_hz') or 0.0):.0f}Hz，"
+                f"高音保护起点 {threshold:.0f}Hz → {next_threshold:.0f}Hz，重新推理",
+            )
+            threshold = next_threshold
+            params.high_pitch_threshold = threshold
+        return rendered, history, guard_applied_any
+
+    @staticmethod
     def _estimate_peak_f0(source: Path) -> float:
         try:
             import numpy as np
+
+            ''' 
+            So-VITS-SVC 在守护程序运行前已立即生成基于模型的F0曲线。当可用时可重复使用：
+            下方轻量级自相关探测器可能将强谐波误认为2 kHz基频，从而在普通语音上触发保护。
+            '''
+            if source.name.lower() in {"infer_input.wav", "vocals_repaired.wav"}:
+                sidecar = source.with_name("f0.npy")
+                try:
+                    source_mtime = source.stat().st_mtime
+                    sidecar_mtime = sidecar.stat().st_mtime
+                    if sidecar_mtime >= source_mtime - 120.0:
+                        curve = np.asarray(np.load(str(sidecar), allow_pickle=False)).reshape(-1)
+                        voiced = curve[np.isfinite(curve) & (curve > 0.0)]
+                        if voiced.size >= 4:
+                            return float(np.max(voiced))
+                except (OSError, ValueError, TypeError):
+                    pass
 
             with wave.open(str(source), "rb") as handle:
                 rate = int(handle.getframerate() or 44100)
@@ -406,7 +1170,7 @@ class ConversionService:
                 return 0.0
             min_lag = max(2, int(target_rate / 2000.0))
             max_lag = min(frame - 1, int(target_rate / 60.0))
-            highest = 0.0
+            estimates: list[float] = []
             for start in range(0, max(1, len(audio) - frame + 1), max(1, frame // 2)):
                 chunk = audio[start : start + frame]
                 if len(chunk) < frame:
@@ -426,8 +1190,13 @@ class ConversionService:
                 ]
                 lag = peaks[0] if peaks else min_lag + int(np.argmax(corr[min_lag:max_lag + 1]))
                 if float(corr[lag]) >= 0.35:
-                    highest = max(highest, target_rate / float(lag))
-            return float(highest)
+                    estimates.append(target_rate / float(lag))
+            if not estimates:
+                return 0.0
+            '''将孤立的八度/泛音误差视为异常值。第85百分位数仍能捕捉到持续的高音，
+                同时防止一个噪点帧导致整个音轨变成被保护的通过。
+            '''
+            return float(np.percentile(np.asarray(estimates, dtype=np.float32), 85.0))
         except (OSError, ValueError, wave.Error, ImportError):
             return 0.0
 
@@ -698,6 +1467,7 @@ class ConversionService:
             work["duration"] = self._format_duration(duration)
             self._record_history(work)
             self._save(work)
+            self._cleanup_finished_work_cache(work_dir, work, log_file)
             self._log(log_file, f"AI 增强任务完成: {output}")
         except Exception as exc:  # noqa: BLE001 - 后台任务必须记录失败原因
             work["status"] = JobStatus.FAILED.value
@@ -759,6 +1529,14 @@ class ConversionService:
             pipeline_total = (7 if enhancement_enabled else 6) + int(harmony_enabled)
             framework = config.modelhub_normalize_framework(work.get("framework"))
             is_sovits = framework == "so-vits-svc"
+            model_profile = {
+                "framework": framework,
+                "main_config_path": work.get("main_config_path", ""),
+                "metadata": work.get("model_metadata") or {},
+            }
+            params.high_pitch_threshold = self._model_high_pitch_threshold(
+                params, model_profile, framework
+            )
             engine = self._engines.for_framework(framework)
             source = Path(work["source_path"]) if work.get("source_path") else None
             duration = (
@@ -940,37 +1718,27 @@ class ConversionService:
                 f"[4/{pipeline_total}] {fw_label} 推理开始（引擎 {'可用' if getattr(engine, 'available', False) else '降级模式'}）",
             )
             raw_converted = work_dir / "converted_raw.wav"
-            guarded_input, guard_enabled = self._prepare_high_pitch_guard(
-                original_infer_input,
-                work_dir / "infer_input_high_guarded.wav",
-                params,
-                log_file,
-            )
-            work["high_pitch_guard_applied"] = bool(guard_enabled)
-            self._save(work)
-            engine.infer(
-                model={
-                    "framework": framework,
-                    "main_model_path": work.get("main_model_path", ""),
-                    "main_config_path": work.get("main_config_path", ""),
-                    "diffusion_model_path": work.get("diffusion_model_path", ""),
-                    "diffusion_config_path": work.get("diffusion_config_path", ""),
-                    "index_path": work.get("index_path", ""),
-                },
-                vocals=guarded_input,
-                out_path=raw_converted,
+            model_payload = {
+                "framework": framework,
+                "main_model_path": work.get("main_model_path", ""),
+                "main_config_path": work.get("main_config_path", ""),
+                "diffusion_model_path": work.get("diffusion_model_path", ""),
+                "diffusion_config_path": work.get("diffusion_config_path", ""),
+                "index_path": work.get("index_path", ""),
+            }
+            raw_converted, recovery_history, guard_enabled = self._infer_with_dropout_recovery(
+                engine=engine,
+                model=model_payload,
+                source=original_infer_input,
+                output=raw_converted,
                 params=params,
                 duration=duration,
                 log_file=log_file,
+                allow_recovery=True,
             )
-            if guard_enabled:
-                raw_converted = self._restore_high_pitch_guard(
-                    raw_converted,
-                    work_dir / "converted_raw_restored.wav",
-                    original_infer_input,
-                    params,
-                    log_file,
-                )
+            work["high_pitch_guard_applied"] = bool(guard_enabled)
+            work["inference_dropout_recovery"] = recovery_history
+            self._save(work)
             self._set_step(work, "infer", StepStatus.DONE.value)
             work["progress"] = 68
             self._save(work)
@@ -1046,6 +1814,7 @@ class ConversionService:
             work["duration"] = self._format_duration(duration)
             self._record_history(work)
             self._save(work)
+            self._cleanup_finished_work_cache(work_dir, work, log_file)
             self._log(log_file, "任务完成 ✅")
         except Exception as exc:  # noqa: BLE001 - 任务失败需记录而非崩溃
             work["status"] = JobStatus.FAILED.value
@@ -1074,6 +1843,130 @@ class ConversionService:
         except (OSError, ValueError):
             pass
         return source
+
+    def _cleanup_finished_work_cache(
+        self,
+        work_dir: Path,
+        work: dict[str, Any],
+        log_file: Path,
+    ) -> None:
+        """清理任务完成后的推理临时文件，同时保留编辑器会引用的素材。
+
+        高音保护会为每次重试生成多份整轨 wav 和 regions 报告。它们只在当前
+        推理期间使用；编辑器真正需要的是作品记录中的路径和 ``editor_segments``
+        分段素材。清理采用白名单保护 + 明确临时文件模式，任何未知文件都不删除。
+        """
+        try:
+            base = work_dir.resolve()
+            if not base.is_dir():
+                return
+        except OSError:
+            return
+
+        protected: set[Path] = set()
+
+        def remember(value: Any) -> None:
+            if isinstance(value, dict):
+                for child in value.values():
+                    remember(child)
+                return
+            if isinstance(value, (list, tuple, set)):
+                for child in value:
+                    remember(child)
+                return
+            if not isinstance(value, str) or not value.strip():
+                return
+            try:
+                candidate = Path(value)
+                if not candidate.is_absolute():
+                    candidate = base / candidate
+                resolved = candidate.resolve()
+                if resolved == base or base in resolved.parents:
+                    protected.add(resolved)
+            except (OSError, ValueError):
+                return
+
+        remember(work)
+        # This is also protected when a task is in manual-vocal-merge mode and
+        # its paths are only present in editor metadata created immediately next.
+        editor_root = (base / "editor_segments").resolve()
+        protected.add(editor_root)
+        # Keep the normalized inference input as an optional muted editor track.
+        infer_input = (base / "infer_input.wav").resolve()
+        if infer_input.is_file():
+            protected.add(infer_input)
+
+        transient_patterns = (
+            "*_dropout_retry*.wav",
+            "*_high_guarded_retry*.wav",
+            "*_restored_retry*.wav",
+            "*_guarded_merged_retry*.wav",
+            "*.regions.json",
+            "f0.npy",
+            "source.wav",
+        )
+        removed = 0
+        released_bytes = 0
+        seen: set[Path] = set()
+
+        def remove_if_unprotected(candidate: Path) -> None:
+            nonlocal removed, released_bytes
+            try:
+                resolved = candidate.resolve()
+                if (
+                    resolved in seen
+                    or not resolved.is_file()
+                    or resolved in protected
+                    or resolved == editor_root
+                    or editor_root in resolved.parents
+                    or base not in resolved.parents
+                ):
+                    return
+                seen.add(resolved)
+                size = resolved.stat().st_size
+                resolved.unlink()
+                removed += 1
+                released_bytes += size
+            except (OSError, ValueError):
+                return
+
+        for pattern in transient_patterns:
+            try:
+                candidates = base.rglob(pattern)
+            except OSError:
+                continue
+            for candidate in candidates:
+                remove_if_unprotected(candidate)
+
+        # Separation and optional vocal-cleanup tools also leave large working
+        # trees.  Their selected output is protected through the work record;
+        # only unreferenced files are removed, then empty cache directories are
+        # pruned.  This keeps editor projects that point at a selected stem safe.
+        for root_name in ("original_stems", "cover_stems", "dereverb", "harmony"):
+            cache_root = base / root_name
+            if not cache_root.is_dir():
+                continue
+            try:
+                for candidate in cache_root.rglob("*"):
+                    if candidate.is_file():
+                        remove_if_unprotected(candidate)
+                directories = sorted(
+                    (item for item in cache_root.rglob("*") if item.is_dir()),
+                    key=lambda item: len(item.parts),
+                    reverse=True,
+                )
+                for directory in [*directories, cache_root]:
+                    try:
+                        directory.rmdir()
+                    except OSError:
+                        pass
+            except OSError:
+                continue
+        if removed:
+            self._log(
+                log_file,
+                f"  已清理推理临时缓存 {removed} 个，释放约 {released_bytes / (1024 * 1024):.1f} MB；编辑器素材已保留",
+            )
 
     @staticmethod
     def _build_timeline(
@@ -1137,6 +2030,26 @@ class ConversionService:
                 shared.get("autoHighPitchGuard", True),
             )
             params["auto_high_pitch_guard"] = guard
+        if (
+            "manual_params_enabled" not in params
+            and "manualParamsEnabled" not in params
+        ):
+            shared = fallback if isinstance(fallback, dict) else {}
+            params["manual_params_enabled"] = shared.get(
+                "manual_params_enabled",
+                shared.get("manualParamsEnabled", True),
+            )
+        if (
+            "high_pitch_guard_rounds" not in params
+            and "highPitchGuardRounds" not in params
+        ):
+            shared = fallback if isinstance(fallback, dict) else {}
+            shared_rounds = shared.get(
+                "high_pitch_guard_rounds",
+                shared.get("highPitchGuardRounds"),
+            )
+            if shared_rounds is not None:
+                params["high_pitch_guard_rounds"] = shared_rounds
         return InferenceParams.from_dict(params)
 
     def _run_multi(self, work_id: str) -> None:
@@ -1314,10 +2227,14 @@ class ConversionService:
             )
             full_renders: dict[str, Path] = {}
             high_pitch_guard_any = False
+            recovery_history: dict[str, list[dict[str, Any]]] = {}
             for n, mid in enumerate(used_models):
                 model = seg_models.get(mid) or {}
                 seg_params = self._multi_model_params(model, work.get("params"))
                 seg_framework = config.modelhub_normalize_framework(model.get("framework"))
+                seg_params.high_pitch_threshold = self._model_high_pitch_threshold(
+                    seg_params, model, seg_framework
+                )
                 self._adapt_high_range(
                     seg_params,
                     audio_profile,
@@ -1326,13 +2243,6 @@ class ConversionService:
                 )
                 seg_engine = self._engines.for_framework(seg_framework)
                 full_raw = work_dir / f"full_{mid}.wav"
-                guarded_input, guard_enabled = self._prepare_high_pitch_guard(
-                    original_infer_input,
-                    work_dir / f"infer_input_{mid}_high_guarded.wav",
-                    seg_params,
-                    log_file,
-                )
-                high_pitch_guard_any = high_pitch_guard_any or guard_enabled
                 fw_label = config.MODELHUB_FRAMEWORKS.get(seg_framework, seg_framework)
                 self._log(
                     log_file,
@@ -1340,7 +2250,8 @@ class ConversionService:
                     f"[{fw_label}] 整轨推理（引擎 {'可用' if getattr(seg_engine, 'available', False) else '降级模式'}）…",
                 )
                 try:
-                    seg_engine.infer(
+                    full_raw, model_recovery, guard_enabled = self._infer_with_dropout_recovery(
+                        engine=seg_engine,
                         model={
                             "framework": seg_framework,
                             "main_model_path": model.get("main_model_path", ""),
@@ -1349,20 +2260,15 @@ class ConversionService:
                             "diffusion_config_path": model.get("diffusion_config_path", ""),
                             "index_path": model.get("index_path", ""),
                         },
-                        vocals=guarded_input,
-                        out_path=full_raw,
+                        source=original_infer_input,
+                        output=full_raw,
                         params=seg_params,
                         duration=duration,
                         log_file=log_file,
+                        allow_recovery=True,
                     )
-                    if guard_enabled:
-                        full_raw = self._restore_high_pitch_guard(
-                            full_raw,
-                            work_dir / f"full_{mid}_restored.wav",
-                            original_infer_input,
-                            seg_params,
-                            log_file,
-                        )
+                    recovery_history[mid] = model_recovery
+                    high_pitch_guard_any = high_pitch_guard_any or guard_enabled
                     # 规整到 44100Hz 且锁定为整曲时长：保证逐句切片与原伴奏精确对齐
                     full_fix = work_dir / f"full_{mid}_fix.wav"
                     if self._ffmpeg.available and self._ffmpeg.pad_or_trim(
@@ -1377,6 +2283,7 @@ class ConversionService:
                 self._save(work)
             self._set_step(work, "infer", StepStatus.DONE.value)
             work["progress"] = 75
+            work["inference_dropout_recovery"] = recovery_history
             self._save(work)
 
             manual_vocal_merge = (
@@ -1504,6 +2411,7 @@ class ConversionService:
                 work["duration"] = self._format_duration(duration)
                 self._record_history(work)
                 self._save(work)
+                self._cleanup_finished_work_cache(work_dir, work, log_file)
                 self._log(log_file, "=== 完成：可编辑人声片段已准备 ===")
                 return
 
@@ -1686,6 +2594,7 @@ class ConversionService:
             work["duration"] = self._format_duration(duration)
             self._record_history(work)
             self._save(work)
+            self._cleanup_finished_work_cache(work_dir, work, log_file)
             self._log(log_file, "任务完成 ✅")
         except Exception as exc:  # noqa: BLE001 - 任务失败需记录而非崩溃
             work["status"] = JobStatus.FAILED.value

--- a/app/application/conversion_service.py
+++ b/app/application/conversion_service.py
@@ -129,6 +129,45 @@ class ConversionService:
         except (TypeError, ValueError):
             configured = default_rounds
         return max(0, min(cls._MAX_HIGH_PITCH_GUARD_ROUNDS, configured))
+
+    @classmethod
+    def _guard_semitones_for_retry(
+        cls,
+        threshold: float,
+        issue: dict[str, Any] | None = None,
+        source: Path | None = None,
+        regions: list[tuple[float, float]] | None = None,
+    ) -> int:
+        """Increase the protective drop only when a retry still misses high notes."""
+        source_f0 = float((issue or {}).get("source_f0_hz") or 0.0)
+        if source and regions:
+            try:
+                import numpy as np
+
+                sidecar = source.with_name("f0.npy")
+                if sidecar.is_file() and sidecar.stat().st_mtime >= source.stat().st_mtime - 120.0:
+                    curve = np.asarray(np.load(str(sidecar), allow_pickle=False)).reshape(-1)
+                    if curve.size >= 4:
+                        with wave.open(str(source), "rb") as handle:
+                            duration = handle.getnframes() / float(handle.getframerate() or 1)
+                        times = np.linspace(0.0, duration, curve.size)
+                        peaks: list[float] = []
+                        for start, end in regions:
+                            values = curve[(times >= start) & (times <= end)]
+                            values = values[np.isfinite(values) & (values > 0.0)]
+                            if values.size:
+                                peaks.append(float(np.max(values)))
+                        if peaks:
+                            source_f0 = max(source_f0, max(peaks))
+            except (OSError, ValueError, TypeError, ImportError):
+                pass
+        excess = source_f0 - float(threshold or cls._HIGH_PITCH_THRESHOLD)
+        if source_f0 >= 950.0 or excess >= 220.0:
+            return 12
+        if source_f0 >= 780.0 or excess >= 80.0:
+            return 9
+        return cls._HIGH_PITCH_GUARD_SEMITONES
+
     def __init__(
         self,
         repo: ListRepository,
@@ -441,6 +480,7 @@ class ConversionService:
         log_file: Path,
         threshold: float | None = None,
         only_regions: list[tuple[float, float]] | None = None,
+        semitones: int | None = None,
     ) -> tuple[Path, bool]:
         """Prepare a selective high-note pitch guard for normal AI covers."""
         if not params.auto_high_pitch_guard or not source.is_file():
@@ -450,11 +490,12 @@ class ConversionService:
         if peak_f0 < high_threshold:
             return source, False
         report_path = destination.with_suffix(".regions.json")
+        shift_semitones = int(semitones or self._HIGH_PITCH_GUARD_SEMITONES)
         try:
             guard_ok = self._ffmpeg.pitch_shift(
                 source,
                 destination,
-                -self._HIGH_PITCH_GUARD_SEMITONES,
+                -shift_semitones,
                 mask_source=source,
                 loudness_source=source,
                 high_threshold=high_threshold,
@@ -470,7 +511,7 @@ class ConversionService:
             guard_ok = self._ffmpeg.pitch_shift(
                 source,
                 destination,
-                -self._HIGH_PITCH_GUARD_SEMITONES,
+                -shift_semitones,
                 mask_source=source,
                 loudness_source=source,
                 high_threshold=high_threshold,
@@ -501,7 +542,7 @@ class ConversionService:
         self._log(
             log_file,
             f"  高音保护已启用：仅处理 {region_count} 个高音区，共 {processed_seconds:.2f}s "
-            f"（阈值 {high_threshold:.0f}Hz，降调 -{self._HIGH_PITCH_GUARD_SEMITONES} 半音；"
+            f"（阈值 {high_threshold:.0f}Hz，降调 -{shift_semitones} 半音；"
             f"区间 {region_preview}）",
         )
         return destination, True
@@ -515,15 +556,17 @@ class ConversionService:
         log_file: Path,
         threshold: float | None = None,
         only_regions: list[tuple[float, float]] | None = None,
+        semitones: int | None = None,
     ) -> Path:
         if not params.auto_high_pitch_guard:
             return source
         restored = destination
+        shift_semitones = int(semitones or self._HIGH_PITCH_GUARD_SEMITONES)
         try:
             restore_ok = self._ffmpeg.pitch_shift(
                 source,
                 destination,
-                self._HIGH_PITCH_GUARD_SEMITONES,
+                shift_semitones,
                 mask_source=original,
                 loudness_source=original,
                 high_threshold=float(threshold or getattr(params, "high_pitch_threshold", 0.0) or self._HIGH_PITCH_THRESHOLD),
@@ -537,7 +580,7 @@ class ConversionService:
             restore_ok = self._ffmpeg.pitch_shift(
                 source,
                 destination,
-                self._HIGH_PITCH_GUARD_SEMITONES,
+                shift_semitones,
                 mask_source=original,
                 loudness_source=original,
                 high_threshold=float(threshold or getattr(params, "high_pitch_threshold", 0.0) or self._HIGH_PITCH_THRESHOLD),
@@ -971,6 +1014,7 @@ class ConversionService:
         guard_applied_any = False
         rendered = output
         guard_regions: list[tuple[float, float]] | None = None
+        guard_semitones = self._HIGH_PITCH_GUARD_SEMITONES
 
         def run_inference(vocals: Path, target: Path) -> None:
             if infer is None:
@@ -1031,6 +1075,12 @@ class ConversionService:
                 if isinstance(item, dict)
                 and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
             ] or None
+            guard_semitones = self._guard_semitones_for_retry(
+                threshold,
+                issue,
+                source,
+                guard_regions,
+            )
             if issue.get("bad_regions") and not params.manual_params_enabled:
                 attempts = max(attempts, self._DROPOUT_RECOVERY_OFFLINE_MAX_ATTEMPTS)
 
@@ -1052,6 +1102,7 @@ class ConversionService:
                 log_file,
                 threshold,
                 guard_regions,
+                guard_semitones,
             )
             guard_applied_any = guard_applied_any or guard_applied
             run_inference(guarded, raw_target)
@@ -1066,6 +1117,7 @@ class ConversionService:
                     log_file,
                     threshold,
                     guard_regions,
+                    guard_semitones,
                 )
                 if baseline_first and rendered != output:
                     merged_target = output.with_name(f"{output.stem}_guarded_merged_retry{attempt}.wav")
@@ -1112,6 +1164,20 @@ class ConversionService:
                     best_render = rendered
                     best_bad_frames = candidate_bad_frames
                     best_guard_applied = guard_applied
+                if guard_regions and issue.get("bad_regions"):
+                    overlaps_scope = any(
+                        float(item.get("end", 0.0)) > start
+                        and float(item.get("start", 0.0)) < end
+                        for item in (issue.get("bad_regions") or [])
+                        if isinstance(item, dict)
+                        for start, end in guard_regions
+                    )
+                    if not overlaps_scope:
+                        self._log(
+                            log_file,
+                            "  新检测到的哑音位于本轮保护范围外，停止继续降低阈值并保留当前最佳结果",
+                        )
+                        return best_render, history, best_guard_applied
             next_threshold = self._next_dropout_threshold(threshold, issue)
             entry["next_threshold"] = next_threshold
             if next_threshold >= threshold - 10.0 or guard_attempt >= guard_attempts - 1:
@@ -1145,6 +1211,15 @@ class ConversionService:
                 f"源 F0 {issue['source_f0_hz']:.0f}Hz / "
                 f"输出 F0 {float(issue.get('output_f0_hz') or 0.0):.0f}Hz，"
                 f"高音保护起点 {threshold:.0f}Hz → {next_threshold:.0f}Hz，重新推理",
+            )
+            guard_semitones = max(
+                guard_semitones,
+                self._guard_semitones_for_retry(
+                    next_threshold,
+                    issue,
+                    source,
+                    guard_regions,
+                ),
             )
             threshold = next_threshold
             params.high_pitch_threshold = threshold

--- a/app/application/model_service.py
+++ b/app/application/model_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -87,7 +88,8 @@ class ModelService:
         return items[0]["id"] if items else None
 
     def get(self, model_id: str) -> dict[str, Any] | None:
-        return self._repo.get(model_id)
+        item = self._repo.get(model_id)
+        return self._normalize_item(item, refresh_size=False) if item else None
 
     # ---- 命令 ----
     def import_model(self, payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -194,6 +196,12 @@ class ModelService:
             index_file=index_file,
         )
         record = self._normalize_item(info.to_dict(), refresh_size=True)
+        inferred_profile = self._infer_pitch_profile(main_config.path if main_config else "", framework)
+        if inferred_profile:
+            record["metadata"] = {
+                **(record.get("metadata") or {}),
+                "inference_profile": inferred_profile,
+            }
         source_repo_id = str(payload.get("source_repo_id") or "").strip().strip("/")
         if source_repo_id:
             source_tags = payload.get("source_tags")
@@ -212,12 +220,61 @@ class ModelService:
             self._settings.set("default_model_id", model_id)
         return record
 
+    @staticmethod
+    def _infer_pitch_profile(config_path: str, framework: str) -> dict[str, float] | None:
+        """Read a model's declared F0 ceiling when its config provides one."""
+        if not config_path:
+            return None
+        values: list[Any] = []
+        try:
+            raw = Path(config_path).read_text(encoding="utf-8")
+            try:
+                parsed = json.loads(raw)
+
+                def visit(value: Any) -> None:
+                    if isinstance(value, dict):
+                        for key, child in value.items():
+                            if str(key).lower() in {"f0_max", "f0_max_hz", "max_f0"}:
+                                values.append(child)
+                            visit(child)
+                    elif isinstance(value, list):
+                        for child in value:
+                            visit(child)
+
+                visit(parsed)
+            except (TypeError, ValueError):
+                for key in ("f0_max", "f0_max_hz", "max_f0"):
+                    match = re.search(rf"(?:^|\n)\s*{key}\s*:\s*([0-9]+(?:\.[0-9]+)?)", raw, re.I)
+                    if match:
+                        values.append(match.group(1))
+        except OSError:
+            return None
+        for value in values:
+            try:
+                ceiling = float(value)
+            except (TypeError, ValueError):
+                continue
+            if 300.0 <= ceiling <= 2000.0:
+                return {"f0_max_hz": ceiling, "high_pitch_threshold": ceiling}
+        return None
+
     def toggle_favorite(self, model_id: str) -> dict[str, Any] | None:
         item = self._repo.get(model_id)
         if not item:
             return None
         item = self._normalize_item(item, refresh_size=False)
         item["favorite"] = not bool(item.get("favorite"))
+        self._repo.update(model_id, item)
+        return item
+
+    def rename(self, model_id: str, name: str) -> dict[str, Any] | None:
+        """Rename a model without touching its managed files."""
+        item = self._repo.get(model_id)
+        normalized_name = " ".join(str(name or "").split())
+        if not item or not normalized_name or len(normalized_name) > 120:
+            return None
+        item = self._normalize_item(item, refresh_size=False)
+        item["name"] = normalized_name
         self._repo.update(model_id, item)
         return item
 
@@ -323,11 +380,21 @@ class ModelService:
         normalized.setdefault("favorite", False)
         normalized.setdefault("tags", [])
         normalized.setdefault("metadata", {})
-        normalized["metadata"] = {
+        metadata = {
             "schema": "xb-svcb.model.v1",
             "framework": framework,
             **(normalized.get("metadata") or {}),
         }
+        # Older model records predate pitch-profile metadata.  Probe their
+        # declared F0 ceiling on read so every inference path can use the
+        # selected model's own range without requiring a re-import.
+        if not metadata.get("inference_profile"):
+            config_entry = normalized.get("main_config")
+            config_path = config_entry.get("path") if isinstance(config_entry, dict) else ""
+            inferred = self._infer_pitch_profile(str(config_path or ""), framework)
+            if inferred:
+                metadata["inference_profile"] = inferred
+        normalized["metadata"] = metadata
         if not normalized.get("type"):
             if framework == "rvc":
                 normalized["type"] = ModelType.RVC.value

--- a/app/application/plugin_service.py
+++ b/app/application/plugin_service.py
@@ -47,7 +47,8 @@ _ALLOWED_PARAMS = {
     "pitch", "f0_method", "index_rate", "rms_mix", "uvr_model", "diffusion_ratio",
     "device", "protect", "filter_radius", "rvc_version", "ddsp_infer_steps",
     "ddsp_formant_shift", "speaker",
-    "auto_high_pitch_guard",
+    "auto_high_pitch_guard", "high_pitch_guard_rounds", "high_pitch_threshold", "f0_filter_threshold",
+    "manual_params_enabled",
 }
 
 

--- a/app/application/realtime_cover_service.py
+++ b/app/application/realtime_cover_service.py
@@ -25,6 +25,7 @@ from infrastructure.ffmpeg_tool import FfmpegTool
 from infrastructure.uvr_tool import UvrTool
 from infrastructure.system_audio import SystemAudioReader, SystemAudioWriter, list_devices
 
+from .conversion_service import ConversionService
 from .model_service import ModelService
 
 
@@ -32,7 +33,9 @@ class RealtimeCoverService:
     """Manage progressive RVC / SeedVC song playback sessions."""
 
     _FRAMEWORKS = {"rvc", "seed-vc"}
-    _HIGH_PITCH_THRESHOLD = 800.0
+    # Realtime favors a stable, slightly conservative boundary over per-model
+    # metadata because blocks must be processed immediately and consistently.
+    _HIGH_PITCH_THRESHOLD = 720.0
 
     def __init__(
         self,
@@ -330,44 +333,41 @@ class RealtimeCoverService:
                 if not self._ffmpeg.slice(vocals, start, end, raw_vocal):
                     raise RuntimeError(f"无法截取第 {index + 1} 个实时人声块")
 
-                guarded_vocal, guard_shift = self._prepare_pitch_guard(
-                    raw_vocal,
-                    directory / f"vocal_{index:05d}_guarded.wav",
-                    model_params,
-                    length,
-                )
                 raw_render = directory / f"render_{index:05d}_{model_id}.wav"
                 persistent = worker_sessions.get(model_id)
-                if persistent is not None:
-                    persistent.infer(guarded_vocal, raw_render)
-                else:
-                    engine.infer(
-                        model=model,
-                        vocals=guarded_vocal,
-                        out_path=raw_render,
-                        params=model_params,
-                        duration=length,
-                        log_file=directory / "realtime.log",
-                    )
-                if guard_shift:
-                    restored = directory / f"render_{index:05d}_{model_id}_restored.wav"
-                    if self._pitch_shift(
-                        raw_render,
-                        restored,
-                        -guard_shift,
-                        mask_source=raw_vocal,
-                        loudness_source=raw_vocal,
-                    ):
-                        raw_render = restored
+                def infer_once(vocal: Path, destination: Path) -> None:
+                    if persistent is not None:
+                        persistent.infer(vocal, destination)
                     else:
-                        self._append_realtime_log(
-                            directory / "realtime.log",
-                            "PITCH_GUARD_RESTORE_FAILED\t保共振峰升调失败，保留模型输出\n",
+                        engine.infer(
+                            model=model,
+                            vocals=vocal,
+                            out_path=destination,
+                            params=model_params,
+                            duration=length,
+                            log_file=directory / "realtime.log",
                         )
-                if model_params.auto_high_pitch_guard and self._is_nearly_silent(raw_render, guarded_vocal):
+
+                raw_render, recovery_history = self._infer_with_dropout_recovery(
+                    source=raw_vocal,
+                    output=raw_render,
+                    params=model_params,
+                    model=model,
+                    infer=infer_once,
+                    log_file=directory / "realtime.log",
+                )
+                unresolved_dropout = bool(
+                    recovery_history
+                    and recovery_history[-1].get("issue")
+                )
+                if (
+                    model_params.auto_high_pitch_guard
+                    and unresolved_dropout
+                    and self._is_nearly_silent(raw_render, raw_vocal)
+                ):
                     self._append_realtime_log(
                         directory / "realtime.log",
-                        "PITCH_GUARD_FALLBACK\t模型输出接近静音，回退原始人声\n",
+                        "PITCH_GUARD_FALLBACK\t重试后整块仍接近静音，回退原始人声\n",
                     )
                     raw_render = raw_vocal
                 fixed = directory / f"render_{index:05d}_{model_id}_fixed.wav"
@@ -674,6 +674,104 @@ class RealtimeCoverService:
             "rendered": directory / f"system_render_{index:06d}.wav",
         }
 
+    def _infer_with_dropout_recovery(
+        self,
+        *,
+        source: Path,
+        output: Path,
+        params: InferenceParams,
+        model: dict[str, Any],
+        infer: Any,
+        log_file: Path,
+    ) -> tuple[Path, list[dict[str, Any]]]:
+        """Retry a realtime block when the model mutes a voiced high-note span."""
+        threshold = self._model_high_pitch_threshold(params, model)
+        params.high_pitch_threshold = threshold
+        guard_rounds = ConversionService._high_pitch_guard_rounds(params)
+        attempts = 1 + guard_rounds if params.auto_high_pitch_guard else 1
+        history: list[dict[str, Any]] = []
+        rendered = output
+        for attempt in range(attempts):
+            raw_target = output if attempt == 0 else output.with_name(
+                f"{output.stem}_dropout_retry{attempt}.wav"
+            )
+            if attempt == 0:
+                guarded, guard_shift = source, 0
+            else:
+                guarded, guard_shift = self._prepare_pitch_guard(
+                    source,
+                    output.with_name(f"{output.stem}_guarded_retry{attempt}.wav"),
+                    params,
+                    self._duration(source),
+                    model=model,
+                )
+            infer(guarded, raw_target)
+            rendered = raw_target
+            if guard_shift:
+                restored = output.with_name(f"{output.stem}_restored_retry{attempt}.wav")
+                if self._pitch_shift(
+                    raw_target,
+                    restored,
+                    -guard_shift,
+                    mask_source=source,
+                    loudness_source=source,
+                    high_threshold=threshold,
+                ):
+                    rendered = restored
+                else:
+                    self._append_realtime_log(
+                        log_file,
+                        "PITCH_GUARD_RESTORE_FAILED\t保共振峰升调失败，保留模型输出\n",
+                    )
+            issue = (
+                ConversionService._detect_model_dropout(
+                    source,
+                    rendered,
+                    threshold,
+                    int(getattr(params, "pitch", 0) or 0),
+                )
+                if params.auto_high_pitch_guard and guard_rounds > 0
+                else None
+            )
+            entry: dict[str, Any] = {
+                "attempt": attempt + 1,
+                "threshold": round(threshold, 1),
+                "issue": issue,
+            }
+            history.append(entry)
+            if issue is None:
+                return rendered, history
+            next_threshold = ConversionService._next_dropout_threshold(threshold, issue)
+            entry["next_threshold"] = next_threshold
+            if next_threshold >= threshold - 10.0 or attempt >= attempts - 1:
+                self._append_realtime_log(
+                    log_file,
+                    "PITCH_DROPOUT_UNRESOLVED\t"
+                    f"{issue['start']:.2f}-{issue['end']:.2f}s\t"
+                    f"source_f0={issue['source_f0_hz']:.0f}\t"
+                    f"threshold={threshold:.0f}\n",
+                )
+                return rendered, history
+            self._append_realtime_log(
+                log_file,
+                "PITCH_DROPOUT_RETRY\t"
+                f"{issue['start']:.2f}-{issue['end']:.2f}s\t"
+                f"source_f0={issue['source_f0_hz']:.0f}\t"
+                f"threshold={threshold:.0f}->{next_threshold:.0f}\n",
+            )
+            threshold = next_threshold
+            params.high_pitch_threshold = threshold
+        return rendered, history
+
+    @staticmethod
+    def _duration(source: Path) -> float:
+        try:
+            with wave.open(str(source), "rb") as handle:
+                rate = int(handle.getframerate() or 0)
+                return handle.getnframes() / float(rate) if rate else 0.0
+        except (OSError, ValueError, wave.Error):
+            return 0.0
+
     def _render_system_block(
         self,
         session: dict[str, Any],
@@ -711,37 +809,33 @@ class RealtimeCoverService:
         model_params = InferenceParams.from_dict(
             (session["models"][0].get("params") or {})
         )
-        guarded, guard_shift = self._prepare_pitch_guard(
-            separated,
-            separated.with_name(separated.stem + "_guarded.wav"),
-            model_params,
-            float(prepared["length"]),
-            sample_rate=int(session["sample_rate"]),
+        def infer_once(vocal: Path, destination: Path) -> None:
+            worker.infer(
+                vocal,
+                destination,
+                timeout=max(120.0, float(prepared["length"]) * 20.0),
+            )
+
+        rendered, recovery_history = self._infer_with_dropout_recovery(
+            source=separated,
+            output=rendered,
+            params=model_params,
+            model=session["models"][0],
+            infer=infer_once,
+            log_file=Path(session["directory"]) / "realtime-system.log",
         )
-        worker.infer(
-            guarded,
-            rendered,
-            timeout=max(120.0, float(prepared["length"]) * 20.0),
+        unresolved_dropout = bool(
+            recovery_history
+            and recovery_history[-1].get("issue")
         )
-        if guard_shift:
-            restored = rendered.with_name(rendered.stem + "_restored.wav")
-            if self._pitch_shift(
-                rendered,
-                restored,
-                -guard_shift,
-                mask_source=separated,
-                loudness_source=separated,
-            ):
-                rendered = restored
-            else:
-                self._append_realtime_log(
-                    Path(session["directory"]) / "realtime-system.log",
-                    "PITCH_GUARD_RESTORE_FAILED\t保共振峰升调失败，保留模型输出\n",
-                )
-        if model_params.auto_high_pitch_guard and self._is_nearly_silent(rendered, guarded):
+        if (
+            model_params.auto_high_pitch_guard
+            and unresolved_dropout
+            and self._is_nearly_silent(rendered, separated)
+        ):
             self._append_realtime_log(
                 Path(session["directory"]) / "realtime-system.log",
-                "PITCH_GUARD_FALLBACK\t模型输出接近静音，回退原始人声\n",
+                "PITCH_GUARD_FALLBACK\t重试后整块仍接近静音，回退原始人声\n",
             )
             rendered = separated
         extracted = self._fit_audio(
@@ -811,6 +905,7 @@ class RealtimeCoverService:
         *,
         mask_source: Path | None = None,
         loudness_source: Path | None = None,
+        high_threshold: float | None = None,
     ) -> bool:
         shift = getattr(self._ffmpeg, "pitch_shift", None)
         if not callable(shift):
@@ -823,7 +918,7 @@ class RealtimeCoverService:
                     int(semitones),
                     mask_source=mask_source,
                     loudness_source=loudness_source,
-                    high_threshold=self._HIGH_PITCH_THRESHOLD,
+                    high_threshold=float(high_threshold or self._HIGH_PITCH_THRESHOLD),
                 )
             )
         except TypeError:
@@ -838,6 +933,7 @@ class RealtimeCoverService:
         duration: float,
         *,
         sample_rate: int = 44100,
+        model: dict[str, Any] | None = None,
     ) -> tuple[Path, int]:
         """Lower only detected extreme-high regions before model inference.
 
@@ -848,9 +944,10 @@ class RealtimeCoverService:
         if not params.auto_high_pitch_guard or duration < 0.12:
             return source, 0
         peak_f0 = self._estimate_peak_f0(source, sample_rate)
-        if peak_f0 < self._HIGH_PITCH_THRESHOLD:
+        high_threshold = self._model_high_pitch_threshold(params, model)
+        if peak_f0 < high_threshold:
             return source, 0
-        if not self._pitch_shift(source, destination, -12):
+        if not self._pitch_shift(source, destination, -12, high_threshold=high_threshold):
             self._append_realtime_log(
                 source.with_name("realtime.log"),
                 f"PITCH_GUARD_PREP_FAILED\tpeak_f0={peak_f0:.1f}\n",
@@ -863,55 +960,21 @@ class RealtimeCoverService:
         return destination, -12
 
     @staticmethod
-    def _estimate_peak_f0(source: Path, sample_rate: int = 44100) -> float:
-        """Estimate the highest reliable voiced fundamental in a short block."""
-        try:
-            import numpy as np
+    def _model_high_pitch_threshold(
+        params: InferenceParams, model: dict[str, Any] | None = None
+    ) -> float:
+        explicit = float(getattr(params, "high_pitch_threshold", 0.0) or 0.0)
+        if explicit > 0:
+            return max(300.0, min(2000.0, explicit))
+        return RealtimeCoverService._HIGH_PITCH_THRESHOLD
 
-            with wave.open(str(source), "rb") as handle:
-                rate = int(handle.getframerate() or sample_rate)
-                channels = int(handle.getnchannels() or 1)
-                frames = handle.readframes(handle.getnframes())
-            if not frames:
-                return 0.0
-            audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32)
-            audio = audio.reshape(-1, channels).mean(axis=1)
-            target_rate = min(rate, 16000)
-            if rate != target_rate and audio.size:
-                positions = np.linspace(0, audio.size - 1, max(1, round(audio.size * target_rate / rate)))
-                audio = np.interp(positions, np.arange(audio.size), audio)
-            if audio.size < max(256, int(target_rate * 0.08)):
-                return 0.0
-            frame = min(audio.size, max(1024, int(target_rate * 0.08)))
-            hop = max(1, frame // 2)
-            min_lag = max(2, int(target_rate / 2000.0))
-            max_lag = min(frame - 1, int(target_rate / 60.0))
-            highest = 0.0
-            for start in range(0, max(1, audio.size - frame + 1), hop):
-                chunk = audio[start : start + frame]
-                if chunk.size < frame:
-                    chunk = np.pad(chunk, (0, frame - chunk.size))
-                chunk = chunk - float(np.mean(chunk))
-                energy = float(np.sqrt(np.mean(chunk * chunk)))
-                if energy < 0.008:
-                    continue
-                corr = np.correlate(chunk, chunk, mode="full")[frame - 1 :]
-                base = float(corr[0])
-                if base <= 0.0:
-                    continue
-                corr = corr / base
-                candidates = [
-                    lag
-                    for lag in range(min_lag + 1, max_lag)
-                    if corr[lag] >= corr[lag - 1]
-                    and corr[lag] >= corr[lag + 1]
-                    and corr[lag] >= 0.45
-                ]
-                lag = candidates[0] if candidates else min_lag + int(np.argmax(corr[min_lag : max_lag + 1]))
-                strength = float(corr[lag])
-                if strength >= 0.35:
-                    highest = max(highest, target_rate / float(lag))
-            return float(highest)
+    @staticmethod
+    def _estimate_peak_f0(source: Path, sample_rate: int = 44100) -> float:
+        """Reuse the conversion probe so realtime guard decisions stay consistent."""
+        try:
+            from application.conversion_service import ConversionService
+
+            return float(ConversionService._estimate_peak_f0(source))
         except (OSError, ValueError, wave.Error, ImportError):
             return 0.0
 
@@ -1007,6 +1070,7 @@ class RealtimeCoverService:
                     "main_model_path": (record.get("main_model") or {}).get("path", ""),
                     "main_config_path": (record.get("main_config") or {}).get("path", ""),
                     "index_path": (record.get("index_file") or {}).get("path", ""),
+                    "metadata": record.get("metadata") or {},
                     "params": dict(entry.get("params") or {}),
                 }
             )

--- a/app/application/realtime_cover_service.py
+++ b/app/application/realtime_cover_service.py
@@ -691,6 +691,7 @@ class RealtimeCoverService:
         attempts = 1 + guard_rounds if params.auto_high_pitch_guard else 1
         history: list[dict[str, Any]] = []
         rendered = output
+        guard_regions: list[tuple[float, float]] | None = None
         for attempt in range(attempts):
             raw_target = output if attempt == 0 else output.with_name(
                 f"{output.stem}_dropout_retry{attempt}.wav"
@@ -704,6 +705,7 @@ class RealtimeCoverService:
                     params,
                     self._duration(source),
                     model=model,
+                    only_regions=guard_regions,
                 )
             infer(guarded, raw_target)
             rendered = raw_target
@@ -716,6 +718,7 @@ class RealtimeCoverService:
                     mask_source=source,
                     loudness_source=source,
                     high_threshold=threshold,
+                    only_regions=guard_regions,
                 ):
                     rendered = restored
                 else:
@@ -739,6 +742,13 @@ class RealtimeCoverService:
                 "issue": issue,
             }
             history.append(entry)
+            if issue and issue.get("bad_regions"):
+                guard_regions = [
+                    (float(item.get("start", 0.0)), float(item.get("end", 0.0)))
+                    for item in (issue.get("bad_regions") or [])
+                    if isinstance(item, dict)
+                    and float(item.get("end", 0.0)) > float(item.get("start", 0.0))
+                ] or guard_regions
             if issue is None:
                 return rendered, history
             next_threshold = ConversionService._next_dropout_threshold(threshold, issue)
@@ -906,22 +916,23 @@ class RealtimeCoverService:
         mask_source: Path | None = None,
         loudness_source: Path | None = None,
         high_threshold: float | None = None,
+        only_regions: list[tuple[float, float]] | None = None,
     ) -> bool:
         shift = getattr(self._ffmpeg, "pitch_shift", None)
         if not callable(shift):
             return False
         try:
-            return bool(
-                shift(
-                    source,
-                    destination,
-                    int(semitones),
-                    mask_source=mask_source,
-                    loudness_source=loudness_source,
-                    high_threshold=float(high_threshold or self._HIGH_PITCH_THRESHOLD),
-                )
-            )
+            kwargs: dict[str, Any] = {
+                "mask_source": mask_source,
+                "loudness_source": loudness_source,
+                "high_threshold": float(high_threshold or self._HIGH_PITCH_THRESHOLD),
+            }
+            if only_regions:
+                kwargs["regions"] = only_regions
+            return bool(shift(source, destination, int(semitones), **kwargs))
         except TypeError:
+            if only_regions:
+                return False
             # Keep compatibility with lightweight test doubles and older tools.
             return bool(shift(source, destination, int(semitones)))
 
@@ -934,6 +945,7 @@ class RealtimeCoverService:
         *,
         sample_rate: int = 44100,
         model: dict[str, Any] | None = None,
+        only_regions: list[tuple[float, float]] | None = None,
     ) -> tuple[Path, int]:
         """Lower only detected extreme-high regions before model inference.
 
@@ -947,7 +959,13 @@ class RealtimeCoverService:
         high_threshold = self._model_high_pitch_threshold(params, model)
         if peak_f0 < high_threshold:
             return source, 0
-        if not self._pitch_shift(source, destination, -12, high_threshold=high_threshold):
+        if not self._pitch_shift(
+            source,
+            destination,
+            -12,
+            high_threshold=high_threshold,
+            only_regions=only_regions,
+        ):
             self._append_realtime_log(
                 source.with_name("realtime.log"),
                 f"PITCH_GUARD_PREP_FAILED\tpeak_f0={peak_f0:.1f}\n",

--- a/app/application/work_service.py
+++ b/app/application/work_service.py
@@ -382,10 +382,20 @@ class WorkService:
         preprocess = self._preprocess(payload)
         shared_params = payload.get("params")
         shared_guard: Any = None
+        shared_guard_rounds: Any = None
+        shared_manual: Any = None
         if isinstance(shared_params, dict):
             for key in ("auto_high_pitch_guard", "autoHighPitchGuard"):
                 if key in shared_params:
                     shared_guard = shared_params[key]
+                    break
+            for key in ("high_pitch_guard_rounds", "highPitchGuardRounds"):
+                if key in shared_params:
+                    shared_guard_rounds = shared_params[key]
+                    break
+            for key in ("manual_params_enabled", "manualParamsEnabled"):
+                if key in shared_params:
+                    shared_manual = shared_params[key]
                     break
         seg_models: dict[str, Any] = {}
         for entry in payload.get("models", []) or []:
@@ -407,6 +417,21 @@ class WorkService:
                 model_params["auto_high_pitch_guard"] = (
                     True if shared_guard is None else shared_guard
                 )
+            if (
+                "manual_params_enabled" not in model_params
+                and "manualParamsEnabled" not in model_params
+            ):
+                # New UI payloads carry the switch at the shared level; legacy
+                # payloads keep their historical manual tuning semantics.
+                model_params["manual_params_enabled"] = (
+                    True if shared_manual is None else shared_manual
+                )
+            if (
+                "high_pitch_guard_rounds" not in model_params
+                and "highPitchGuardRounds" not in model_params
+                and shared_guard_rounds is not None
+            ):
+                model_params["high_pitch_guard_rounds"] = shared_guard_rounds
             seg_models[mid] = {
                 "name": model.get("name", mid),
                 "params": model_params,
@@ -543,7 +568,7 @@ class WorkService:
         }
 
     @staticmethod
-    def _resolve_model_paths(model: dict[str, Any] | None) -> dict[str, str]:
+    def _resolve_model_paths(model: dict[str, Any] | None) -> dict[str, Any]:
         """从模型记录提取推理所需的文件路径与框架标识。
 
         返回含 ``framework``（路由引擎用）、so-vits / SeedVC 的 main/config 路径、
@@ -557,6 +582,7 @@ class WorkService:
                 "diffusion_model_path": "",
                 "diffusion_config_path": "",
                 "index_path": "",
+                "model_metadata": {},
             }
         framework = config.modelhub_normalize_framework(
             model.get("framework") or config.modelhub_guess_framework(model.get("type"))
@@ -568,6 +594,7 @@ class WorkService:
             "diffusion_model_path": (model.get("diffusion_model") or {}).get("path", ""),
             "diffusion_config_path": (model.get("diffusion_config") or {}).get("path", ""),
             "index_path": (model.get("index_file") or {}).get("path", ""),
+            "model_metadata": model.get("metadata") or {},
         }
 
     def retry(self, work_id: str) -> bool:

--- a/app/domain/entities.py
+++ b/app/domain/entities.py
@@ -123,6 +123,8 @@ class InferenceParams:
     SeedVC：``reference_audio``（本次推理使用的目标音色参考音频）。
     DDSP-SVC：``ddsp_infer_steps``（Rectified Flow 采样步数）、
     ``ddsp_formant_shift``（共振峰偏移，半音）、``speaker``（说话人 id）。
+    通用高级控制：``high_pitch_guard_rounds``、``f0_filter_threshold``；
+    ``manual_params_enabled`` 关闭时恢复软件默认调参值。
     """
 
     pitch: int = 0
@@ -144,6 +146,16 @@ class InferenceParams:
     reference_audio: str = ""  # SeedVC 目标音色参考音频路径
     ddsp_infer_steps: int = 50  # DDSP-SVC Rectified Flow 采样步数（官方默认质量）
     ddsp_formant_shift: float = 0.0  # DDSP-SVC 共振峰偏移（-2~2 半音）
+    # 0 means automatic model-specific detection.
+    # Legacy/API compatibility only. The full-parameter UI controls retry
+    # rounds instead; conversion services use this as internal boundary state.
+    high_pitch_threshold: float = 0.0
+    # Number of guarded recovery retries after the initial model inference.
+    high_pitch_guard_rounds: int = 3
+    # F0 过滤阈值（0~1），由 F0 提取器用于过滤低置信度候选。
+    f0_filter_threshold: float = 0.05
+    # 关闭时忽略手动调参，使用各引擎的软件默认值。
+    manual_params_enabled: bool = False
     # 高音保护：极高音区域先保共振峰降调，翻唱后再升回原调。
     auto_high_pitch_guard: bool = True
 
@@ -153,7 +165,15 @@ class InferenceParams:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "InferenceParams":
         data = data or {}
-        return cls(
+        manual_present = "manual_params_enabled" in data or "manualParamsEnabled" in data
+        f0_filter_value = data.get("f0_filter_threshold", data.get("f0FilterThreshold", 0.05))
+        guard_rounds_value = data.get(
+            "high_pitch_guard_rounds",
+            data.get("highPitchGuardRounds", 3),
+        )
+        if guard_rounds_value is None:
+            guard_rounds_value = 3
+        params = cls(
             pitch=int(data.get("pitch", 0)),
             f0_method=str(data.get("f0_method", data.get("f0Method", "rmvpe"))),
             index_rate=float(data.get("index_rate", data.get("indexRate", 0.75))),
@@ -199,11 +219,44 @@ class InferenceParams:
                     ),
                 ),
             ),
+            high_pitch_threshold=max(
+                0.0,
+                min(
+                    2000.0,
+                    float(data.get("high_pitch_threshold", data.get("highPitchThreshold", 0.0)) or 0.0),
+                ),
+            ),
+            high_pitch_guard_rounds=max(
+                0,
+                min(
+                    8,
+                    int(guard_rounds_value),
+                ),
+            ),
+            f0_filter_threshold=max(
+                0.0,
+                min(
+                    1.0,
+                    float(f0_filter_value if f0_filter_value is not None else 0.05),
+                ),
+            ),
+            manual_params_enabled=_coerce_bool(
+                data.get("manual_params_enabled", data.get("manualParamsEnabled", False)),
+                False,
+            ),
             auto_high_pitch_guard=_coerce_bool(
                 data.get("auto_high_pitch_guard", data.get("autoHighPitchGuard", True)),
                 True,
             ),
         )
+        # An explicit OFF only suppresses advanced manual fields.  The ordinary
+        # inference controls remain user-adjustable in the default workflow.
+        if manual_present and not params.manual_params_enabled:
+            params.speaker = ""
+            params.high_pitch_threshold = 0.0
+            params.f0_filter_threshold = 0.05
+            params.high_pitch_guard_rounds = 3
+        return params
 
 
 @dataclass

--- a/app/infrastructure/f0_worker.py
+++ b/app/infrastructure/f0_worker.py
@@ -61,6 +61,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--out-npy", required=True, help="F0 曲线输出 .npy 路径")
     p.add_argument("--f0", default="rmvpe", help="F0 预测器")
     p.add_argument("--f0-max", type=float, default=1100.0, help="自适应 F0 上限")
+    p.add_argument("--f0-threshold", type=float, default=0.05, help="F0 置信度过滤阈值")
     p.add_argument(
         "--device",
         default="auto",
@@ -97,6 +98,7 @@ def main() -> int:
         traceback.print_exc()
         return 3
 
+    f0_threshold = max(0.0, min(1.0, float(args.f0_threshold)))
     patch_sovits_fcpe_fallback(utils, args.f0_max)
 
     # 从模型配置读取采样率与 hop，保证与推理时一致
@@ -138,7 +140,7 @@ def main() -> int:
             hop_length=hop_length,
             sampling_rate=sampling_rate,
             device=device,
-            threshold=0.05,
+            threshold=f0_threshold,
         )
         if hasattr(predictor, "f0_max"):
             predictor.f0_max = max(

--- a/app/infrastructure/ffmpeg_tool.py
+++ b/app/infrastructure/ffmpeg_tool.py
@@ -456,6 +456,7 @@ class FfmpegTool:
         mask_source: Path | None = None,
         loudness_source: Path | None = None,
         high_threshold: float = 800.0,
+        report_path: Path | None = None,
     ) -> bool:
         """Pitch-shift only high-note regions while preserving formants.
 
@@ -484,6 +485,8 @@ class FfmpegTool:
                 command.extend(["--mask-source", str(mask_source)])
             if loudness_source:
                 command.extend(["--loudness-source", str(loudness_source)])
+            if report_path:
+                command.extend(["--report-json", str(report_path)])
             result = subprocess.run(
                 command,
                 capture_output=True,

--- a/app/infrastructure/ffmpeg_tool.py
+++ b/app/infrastructure/ffmpeg_tool.py
@@ -457,6 +457,7 @@ class FfmpegTool:
         loudness_source: Path | None = None,
         high_threshold: float = 800.0,
         report_path: Path | None = None,
+        regions: list[tuple[float, float]] | None = None,
     ) -> bool:
         """Pitch-shift only high-note regions while preserving formants.
 
@@ -468,6 +469,7 @@ class FfmpegTool:
         if not python or not Path(str(python)).is_file() or not worker or not Path(str(worker)).is_file():
             return False
         dst.parent.mkdir(parents=True, exist_ok=True)
+        scope_path: Path | None = None
         try:
             command = [
                 str(python),
@@ -487,6 +489,20 @@ class FfmpegTool:
                 command.extend(["--loudness-source", str(loudness_source)])
             if report_path:
                 command.extend(["--report-json", str(report_path)])
+            if regions:
+                scope_path = dst.with_suffix(".scope.json")
+                scope_path.write_text(
+                    json.dumps(
+                        [
+                            {"start": float(start), "end": float(end)}
+                            for start, end in regions
+                            if float(end) > float(start)
+                        ],
+                        ensure_ascii=False,
+                    ),
+                    encoding="utf-8",
+                )
+                command.extend(["--regions-json", str(scope_path)])
             result = subprocess.run(
                 command,
                 capture_output=True,
@@ -556,6 +572,12 @@ class FfmpegTool:
             return True
         except (OSError, subprocess.SubprocessError, ValueError):
             return False
+        finally:
+            if scope_path:
+                try:
+                    scope_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
     def silence(self, dst: Path, duration: float, sample_rate: int = 44100) -> bool:
         """Create a fixed-duration stereo silence file."""

--- a/app/infrastructure/formant_pitch_worker.py
+++ b/app/infrastructure/formant_pitch_worker.py
@@ -110,11 +110,33 @@ def _high_intervals(
                     clipped.append((left, right))
         return clipped
 
-    strict_scoped = clip_to_scope(intervals)
-    if strict_scoped:
-        return strict_scoped
     relaxed_threshold = max(100.0, float(threshold) - max(70.0, hysteresis))
-    return clip_to_scope(build(relaxed_threshold))
+    relaxed_intervals = build(relaxed_threshold)
+    # Resolve each confirmed scope independently. One strict high note must
+    # not suppress the hysteresis fallback for a neighboring lower note.
+    scoped: list[tuple[float, float]] = []
+    context = _REGION_FADE_SECONDS
+    for scope_start, scope_end in scoped_regions:
+        strict_matches = [
+            item
+            for item in intervals
+            if item[1] > scope_start and item[0] < scope_end
+        ]
+        candidates = strict_matches or [
+            item
+            for item in relaxed_intervals
+            if item[1] > scope_start and item[0] < scope_end
+        ]
+        for start, end in candidates:
+            left = max(start, scope_start - context)
+            right = min(end, scope_end + context)
+            if right <= left:
+                continue
+            if scoped and left <= scoped[-1][1] + 0.01:
+                scoped[-1] = (scoped[-1][0], max(scoped[-1][1], right))
+            else:
+                scoped.append((left, right))
+    return scoped
 
 
 def _region_mask(

--- a/app/infrastructure/formant_pitch_worker.py
+++ b/app/infrastructure/formant_pitch_worker.py
@@ -8,7 +8,12 @@ changed; the spectral envelope/formants remain in the source sound.
 from __future__ import annotations
 
 import argparse
+import json
+import math
 from pathlib import Path
+
+
+_REGION_FADE_SECONDS = 0.08
 
 
 def _pitch_points(tier, call) -> list[tuple[float, float]]:  # noqa: ANN001
@@ -40,23 +45,33 @@ def _high_intervals(
     like vibrato/electronic noise, so require two nearby high points before
     enabling a region.
     """
-    high_points = sorted(
+    anchors = sorted(
         (float(time), float(frequency))
         for time, frequency in points
         if frequency >= threshold and xmin <= time <= xmax
     )
-    if len(high_points) < 2:
+    if len(anchors) < 2:
         return []
+    # Keep notes whose F0 briefly dips below the boundary in one region. Two
+    # true high-note anchors are still required, so isolated pitch spikes do
+    # not activate PSOLA.
+    hysteresis = max(35.0, float(threshold) * 0.08)
+    high_points = sorted(
+        (float(time), float(frequency))
+        for time, frequency in points
+        if frequency >= max(100.0, threshold - hysteresis)
+        and xmin <= time <= xmax
+    )
     groups: list[list[tuple[float, float]]] = [[high_points[0]]]
     for point in high_points[1:]:
-        if point[0] - groups[-1][-1][0] <= 0.08:
+        if point[0] - groups[-1][-1][0] <= 0.12:
             groups[-1].append(point)
         else:
             groups.append([point])
-    padding = 0.035
+    padding = 0.06
     intervals: list[tuple[float, float]] = []
     for group in groups:
-        if len(group) < 2:
+        if sum(1 for _, frequency in group if frequency >= threshold) < 2:
             continue
         start = max(xmin, group[0][0] - padding)
         end = min(xmax, group[-1][0] + padding)
@@ -77,7 +92,7 @@ def _region_mask(
     mask = np.zeros(max(0, count), dtype=np.float64)
     if not intervals or count <= 0:
         return mask
-    fade = max(1, int(round(sample_rate * 0.035)))
+    fade = max(1, int(round(sample_rate * _REGION_FADE_SECONDS)))
     for start, end in intervals:
         left = max(0, int(round(start * sample_rate)))
         right = min(count, int(round(end * sample_rate)))
@@ -93,6 +108,35 @@ def _region_mask(
             phase = np.linspace(np.pi / 2.0, 0.0, right_edge - right, endpoint=False)
             mask[right:right_edge] = np.maximum(mask[right:right_edge], np.sin(phase) ** 2)
     return mask
+
+
+def _region_weight_at(
+    time: float,
+    intervals: list[tuple[float, float]],
+    fade: float = _REGION_FADE_SECONDS,
+) -> float:
+    """Return a smooth 0..1 pitch-shift amount at one pitch-tier point.
+
+    The audio blend already fades at the same boundary.  Applying that fade to
+    the pitch tier as well avoids an instantaneous frequency jump inside Praat
+    PSOLA, which otherwise sounds like a dropped frame at every high-note edge.
+    """
+    point = float(time)
+    edge = max(0.01, float(fade))
+    weight = 0.0
+    for start, end in intervals:
+        start = float(start)
+        end = float(end)
+        if start <= point <= end:
+            weight = max(weight, 1.0)
+            continue
+        if start - edge < point < start:
+            phase = (point - (start - edge)) / edge
+            weight = max(weight, math.sin(phase * math.pi / 2.0) ** 2)
+        elif end < point < end + edge:
+            phase = (point - end) / edge
+            weight = max(weight, math.cos(phase * math.pi / 2.0) ** 2)
+    return min(1.0, max(0.0, weight))
 
 
 def _blend_regions(
@@ -141,6 +185,95 @@ def _restore_region_loudness(
     return output_audio
 
 
+def _processing_chunks(
+    intervals: list[tuple[float, float]],
+    duration: float,
+    context: float,
+) -> list[tuple[float, float]]:
+    """Group nearby guarded regions into short PSOLA processing windows."""
+    expanded: list[tuple[float, float]] = []
+    for start, end in intervals:
+        left = max(0.0, float(start) - context)
+        right = min(float(duration), float(end) + context)
+        if right <= left:
+            continue
+        if expanded and left <= expanded[-1][1]:
+            expanded[-1] = (expanded[-1][0], max(expanded[-1][1], right))
+        else:
+            expanded.append((left, right))
+    return expanded
+
+
+def _selective_mono_psola(
+    mono: object,
+    sample_rate: float,
+    source_points: list[tuple[float, float]],
+    intervals: list[tuple[float, float]],
+    ratio: float,
+) -> object:
+    """Render only guarded windows and leave every other sample untouched.
+
+    Running Praat over a multi-minute track can add a phase/noise floor to
+    unrelated material even when the pitch tier is unchanged.  Short windows
+    keep the expensive PSOLA operation inside the selected high-note regions;
+    the resulting mono delta is reused for every channel to preserve stereo
+    phase.
+    """
+    import numpy as np
+    import parselmouth
+    from parselmouth.praat import call
+
+    source_audio = np.asarray(mono, dtype=np.float64).reshape(-1)
+    rendered_audio = source_audio.copy()
+    if not source_audio.size or not intervals or sample_rate <= 0:
+        return rendered_audio
+    total_duration = source_audio.size / float(sample_rate)
+    mask = _region_mask(intervals, sample_rate, source_audio.size)
+    context = _REGION_FADE_SECONDS + 0.08
+    chunks = _processing_chunks(intervals, total_duration, context)
+    for chunk_start, chunk_end in chunks:
+        left = max(0, int(round(chunk_start * sample_rate)))
+        right = min(source_audio.size, int(round(chunk_end * sample_rate)))
+        if right - left < max(256, int(sample_rate * 0.08)):
+            continue
+        segment = source_audio[left:right]
+        segment_sound = parselmouth.Sound(segment, sampling_frequency=sample_rate)
+        manipulation = call(segment_sound, "To Manipulation", 0.005, 55.0, 4000.0)
+        segment_xmin = left / float(sample_rate)
+        points = [
+            (float(time) - segment_xmin, float(frequency))
+            for time, frequency in source_points
+            if segment_xmin <= float(time) <= right / float(sample_rate)
+            and float(frequency) > 0.0
+        ]
+        if not points:
+            # A malformed/empty tier must never replace the original segment.
+            continue
+        selective = call(
+            "Create PitchTier",
+            "Selective high pitch window",
+            segment_sound.xmin,
+            segment_sound.xmax,
+        )
+        for local_time, frequency in points:
+            blend = _region_weight_at(local_time + segment_xmin, intervals)
+            shifted_frequency = frequency * (1.0 + blend * (ratio - 1.0))
+            call(selective, "Add point", local_time, shifted_frequency)
+        call([selective, manipulation], "Replace pitch tier")
+        rendered = call(manipulation, "Get resynthesis (overlap-add)")
+        segment_output = np.asarray(rendered.values, dtype=np.float64).reshape(-1)
+        expected = right - left
+        if segment_output.size > expected:
+            segment_output = segment_output[:expected]
+        elif segment_output.size < expected:
+            segment_output = np.pad(segment_output, (0, expected - segment_output.size))
+        segment_mask = mask[left:right]
+        rendered_audio[left:right] = (
+            segment * (1.0 - segment_mask) + segment_output * segment_mask
+        )
+    return rendered_audio
+
+
 def shift(
     source: Path,
     destination: Path,
@@ -148,7 +281,7 @@ def shift(
     high_threshold: float = 800.0,
     mask_source: Path | None = None,
     loudness_source: Path | None = None,
-) -> None:
+) -> list[tuple[float, float]]:
     import numpy as np
     import parselmouth
     import soundfile as sf
@@ -161,11 +294,11 @@ def shift(
     mono = np.mean(values, axis=0)
     mono_sound = parselmouth.Sound(mono, sampling_frequency=sound.sampling_frequency)
     ratio = 2.0 ** (float(semitones) / 12.0)
-    mask_tier = call(
+    pitch_tier = call(
         call(mono_sound, "To Manipulation", 0.005, 55.0, 4000.0),
         "Extract pitch tier",
     )
-    source_tier = mask_tier
+    mask_tier = pitch_tier
     if mask_source and mask_source.is_file():
         mask_sound = parselmouth.Sound(str(mask_source))
         mask_values = np.asarray(mask_sound.values, dtype=np.float64)
@@ -173,9 +306,14 @@ def shift(
             mask_values = np.mean(mask_values, axis=0)
         mask_mono = parselmouth.Sound(mask_values, sampling_frequency=mask_sound.sampling_frequency)
         mask_manipulation = call(mask_mono, "To Manipulation", 0.005, 55.0, 4000.0)
-        source_tier = call(mask_manipulation, "Extract pitch tier")
+        mask_tier = call(mask_manipulation, "Extract pitch tier")
+    # The source audio owns the pitch contour being shifted.  ``mask_source``
+    # only supplies region boundaries; using its tier here during restoration
+    # would shift the original F0 a second time and overshoot the model output.
+    source_points = _pitch_points(pitch_tier, call)
+    mask_points = _pitch_points(mask_tier, call)
     intervals = _high_intervals(
-        _pitch_points(source_tier, call),
+        mask_points,
         max(100.0, float(high_threshold)),
         sound.xmin,
         sound.xmax,
@@ -198,7 +336,7 @@ def shift(
             int(round(sound.sampling_frequency)),
             subtype="PCM_16",
         )
-        return
+        return []
 
     loudness_reference = mono
     if loudness_source and loudness_source.is_file():
@@ -207,54 +345,26 @@ def shift(
         if reference_values.ndim > 1:
             reference_values = np.mean(reference_values, axis=0)
         loudness_reference = reference_values
-    rendered_channels: list[np.ndarray] = []
-    expected = values.shape[1]
-    for channel in values:
-        channel_sound = parselmouth.Sound(
-            channel,
-            sampling_frequency=sound.sampling_frequency,
-        )
-        manipulation = call(channel_sound, "To Manipulation", 0.005, 55.0, 4000.0)
-        tier = call(manipulation, "Extract pitch tier")
-        channel_points = _pitch_points(tier, call)
-        if not channel_points:
-            # A silent/phase-cancelled side channel has no valid tier.  Keep it
-            # untouched instead of asking Praat to replace an empty tier.
-            rendered_channels.append(channel.copy())
-            continue
-        selective = call(
-            "Create PitchTier",
-            "Selective high pitch",
-            channel_sound.xmin,
-            channel_sound.xmax,
-        )
-        for point_time, frequency in channel_points:
-            active = any(start <= point_time <= end for start, end in intervals)
-            call(
-                selective,
-                "Add point",
-                point_time,
-                frequency * ratio if active else frequency,
-            )
-        call([selective, manipulation], "Replace pitch tier")
-        rendered = call(manipulation, "Get resynthesis (overlap-add)")
-        channel_output = np.asarray(rendered.values, dtype=np.float64).reshape(-1)
-        if channel_output.size > expected:
-            channel_output = channel_output[:expected]
-        elif channel_output.size < expected:
-            channel_output = np.pad(channel_output, (0, expected - channel_output.size))
-        rendered_channels.append(channel_output)
-    # Blend only the selected regions; outside them the source remains bitwise
-    # unchanged, avoiding full-track PSOLA artifacts in consonants and lows.
+    # Render a single mono delta in short windows.  Reusing that delta for both
+    # channels prevents stereo phase drift and guarantees non-high regions are
+    # copied from the original input.
+    rendered_mono = _selective_mono_psola(
+        mono,
+        float(sound.sampling_frequency),
+        source_points,
+        intervals,
+        ratio,
+    )
+    mono_delta = np.asarray(rendered_mono, dtype=np.float64) - mono
     output = np.vstack(
         [
             _restore_region_loudness(
                 loudness_reference,
-                _blend_regions(source_channel, channel, intervals, sound.sampling_frequency),
+                np.asarray(source_channel, dtype=np.float64) + mono_delta,
                 intervals,
                 sound.sampling_frequency,
             )
-            for source_channel, channel in zip(values, rendered_channels)
+            for source_channel in values
         ]
     )
     output = np.clip(
@@ -264,6 +374,7 @@ def shift(
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
     sf.write(str(destination), output, int(round(sound.sampling_frequency)), subtype="PCM_16")
+    return intervals
 
 
 def _validate_render(source: Path, destination: Path) -> tuple[bool, str]:
@@ -310,17 +421,58 @@ def main() -> int:
     parser.add_argument("--high-threshold", type=float, default=800.0)
     parser.add_argument("--mask-source", default="")
     parser.add_argument("--loudness-source", default="")
+    parser.add_argument(
+        "--report-json",
+        default="",
+        help="可选：将实际处理的高音区间写入 JSON",
+    )
     args = parser.parse_args()
     source = Path(args.input)
     destination = Path(args.output)
     try:
-        shift(
+        intervals = shift(
             source,
             destination,
             args.semitones,
             high_threshold=args.high_threshold,
             mask_source=Path(args.mask_source) if args.mask_source else None,
             loudness_source=Path(args.loudness_source) if args.loudness_source else None,
+        )
+        if args.report_json:
+            report_path = Path(args.report_json)
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(
+                json.dumps(
+                    {
+                        "threshold_hz": float(args.high_threshold),
+                        "semitones": float(args.semitones),
+                        "region_count": len(intervals),
+                        "processed_seconds": round(
+                            sum(end - start for start, end in intervals), 3
+                        ),
+                        "regions": [
+                            {
+                                "start": round(start, 3),
+                                "end": round(end, 3),
+                                "duration": round(end - start, 3),
+                            }
+                            for start, end in intervals
+                        ],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+        preview = ",".join(
+            f"{start:.2f}-{end:.2f}s" for start, end in intervals[:8]
+        )
+        if len(intervals) > 8:
+            preview += ",..."
+        print(
+            f"FORMANT_PITCH_REGIONS\t{len(intervals)}\t"
+            f"{sum(end - start for start, end in intervals):.3f}s\t{preview}",
+            flush=True,
         )
         quality_ok, quality_reason = _validate_render(source, destination)
         if not quality_ok:

--- a/app/infrastructure/formant_pitch_worker.py
+++ b/app/infrastructure/formant_pitch_worker.py
@@ -37,6 +37,7 @@ def _high_intervals(
     threshold: float,
     xmin: float,
     xmax: float,
+    allowed_regions: list[tuple[float, float]] | None = None,
 ) -> list[tuple[float, float]]:
     """Turn *stable* high voiced pitch points into expanded time regions.
 
@@ -45,41 +46,75 @@ def _high_intervals(
     like vibrato/electronic noise, so require two nearby high points before
     enabling a region.
     """
-    anchors = sorted(
-        (float(time), float(frequency))
-        for time, frequency in points
-        if frequency >= threshold and xmin <= time <= xmax
-    )
-    if len(anchors) < 2:
-        return []
-    # Keep notes whose F0 briefly dips below the boundary in one region. Two
-    # true high-note anchors are still required, so isolated pitch spikes do
-    # not activate PSOLA.
     hysteresis = max(35.0, float(threshold) * 0.08)
-    high_points = sorted(
-        (float(time), float(frequency))
-        for time, frequency in points
-        if frequency >= max(100.0, threshold - hysteresis)
-        and xmin <= time <= xmax
+    scoped_regions = sorted(
+        (max(float(start), xmin), min(float(end), xmax))
+        for start, end in (allowed_regions or [])
+        if float(end) > float(start)
+        and min(float(end), xmax) > max(float(start), xmin)
     )
-    groups: list[list[tuple[float, float]]] = [[high_points[0]]]
-    for point in high_points[1:]:
-        if point[0] - groups[-1][-1][0] <= 0.12:
-            groups[-1].append(point)
-        else:
-            groups.append([point])
-    padding = 0.06
-    intervals: list[tuple[float, float]] = []
-    for group in groups:
-        if sum(1 for _, frequency in group if frequency >= threshold) < 2:
-            continue
-        start = max(xmin, group[0][0] - padding)
-        end = min(xmax, group[-1][0] + padding)
-        if intervals and start <= intervals[-1][1] + 0.01:
-            intervals[-1] = (intervals[-1][0], max(intervals[-1][1], end))
-        else:
-            intervals.append((start, end))
-    return intervals
+    def build(anchor_threshold: float) -> list[tuple[float, float]]:
+        anchors = sorted(
+            (float(time), float(frequency))
+            for time, frequency in points
+            if frequency >= anchor_threshold and xmin <= time <= xmax
+        )
+        if len(anchors) < 2:
+            return []
+        # Keep notes whose F0 briefly dips below the boundary in one region.
+        high_points = sorted(
+            (float(time), float(frequency))
+            for time, frequency in points
+            if frequency >= max(100.0, threshold - hysteresis)
+            and xmin <= time <= xmax
+        )
+        if not high_points:
+            return []
+        groups: list[list[tuple[float, float]]] = [[high_points[0]]]
+        for point in high_points[1:]:
+            if point[0] - groups[-1][-1][0] <= 0.12:
+                groups[-1].append(point)
+            else:
+                groups.append([point])
+        padding = 0.06
+        intervals: list[tuple[float, float]] = []
+        for group in groups:
+            if sum(1 for _, frequency in group if frequency >= anchor_threshold) < 2:
+                continue
+            start = max(xmin, group[0][0] - padding)
+            end = min(xmax, group[-1][0] + padding)
+            if intervals and start <= intervals[-1][1] + 0.01:
+                intervals[-1] = (intervals[-1][0], max(intervals[-1][1], end))
+            else:
+                intervals.append((start, end))
+        return intervals
+
+    # Always prefer the strict high-note boundary. A lower hysteresis retry is
+    # considered only when a confirmed dropout scope contains no strict note.
+    intervals = build(float(threshold))
+    if not scoped_regions:
+        return intervals
+
+    def clip_to_scope(source: list[tuple[float, float]]) -> list[tuple[float, float]]:
+        clipped: list[tuple[float, float]] = []
+        context = _REGION_FADE_SECONDS
+        for start, end in source:
+            for scope_start, scope_end in scoped_regions:
+                left = max(start, scope_start - context)
+                right = min(end, scope_end + context)
+                if right <= left:
+                    continue
+                if clipped and left <= clipped[-1][1] + 0.01:
+                    clipped[-1] = (clipped[-1][0], max(clipped[-1][1], right))
+                else:
+                    clipped.append((left, right))
+        return clipped
+
+    strict_scoped = clip_to_scope(intervals)
+    if strict_scoped:
+        return strict_scoped
+    relaxed_threshold = max(100.0, float(threshold) - max(70.0, hysteresis))
+    return clip_to_scope(build(relaxed_threshold))
 
 
 def _region_mask(
@@ -281,6 +316,7 @@ def shift(
     high_threshold: float = 800.0,
     mask_source: Path | None = None,
     loudness_source: Path | None = None,
+    allowed_regions: list[tuple[float, float]] | None = None,
 ) -> list[tuple[float, float]]:
     import numpy as np
     import parselmouth
@@ -317,6 +353,7 @@ def shift(
         max(100.0, float(high_threshold)),
         sound.xmin,
         sound.xmax,
+        allowed_regions=allowed_regions,
     )
 
     # Do not run an unnecessary PSOLA resynthesis when the output has no
@@ -422,6 +459,11 @@ def main() -> int:
     parser.add_argument("--mask-source", default="")
     parser.add_argument("--loudness-source", default="")
     parser.add_argument(
+        "--regions-json",
+        default="",
+        help="仅处理 JSON 中列出的已确认失配区间",
+    )
+    parser.add_argument(
         "--report-json",
         default="",
         help="可选：将实际处理的高音区间写入 JSON",
@@ -430,6 +472,25 @@ def main() -> int:
     source = Path(args.input)
     destination = Path(args.output)
     try:
+        allowed_regions: list[tuple[float, float]] | None = None
+        if args.regions_json:
+            raw_regions = json.loads(Path(args.regions_json).read_text(encoding="utf-8"))
+            if isinstance(raw_regions, list):
+                parsed_regions: list[tuple[float, float]] = []
+                for item in raw_regions:
+                    if isinstance(item, dict):
+                        start, end = item.get("start"), item.get("end")
+                    elif isinstance(item, (list, tuple)) and len(item) >= 2:
+                        start, end = item[0], item[1]
+                    else:
+                        continue
+                    try:
+                        left, right = float(start), float(end)
+                    except (TypeError, ValueError):
+                        continue
+                    if right > left:
+                        parsed_regions.append((left, right))
+                allowed_regions = parsed_regions or None
         intervals = shift(
             source,
             destination,
@@ -437,6 +498,7 @@ def main() -> int:
             high_threshold=args.high_threshold,
             mask_source=Path(args.mask_source) if args.mask_source else None,
             loudness_source=Path(args.loudness_source) if args.loudness_source else None,
+            allowed_regions=allowed_regions,
         )
         if args.report_json:
             report_path = Path(args.report_json)

--- a/app/infrastructure/formant_pitch_worker.py
+++ b/app/infrastructure/formant_pitch_worker.py
@@ -110,7 +110,10 @@ def _high_intervals(
                     clipped.append((left, right))
         return clipped
 
-    relaxed_threshold = max(100.0, float(threshold) - max(70.0, hysteresis))
+    # A confirmed dropout can sit well below the first guard boundary after
+    # the source phrase is transposed. Keep enough hysteresis to include the
+    # neighboring 600-700 Hz notes, but still stay far above speech range.
+    relaxed_threshold = max(100.0, float(threshold) - max(110.0, hysteresis))
     relaxed_intervals = build(relaxed_threshold)
     # Resolve each confirmed scope independently. One strict high note must
     # not suppress the hysteresis fallback for a neighboring lower note.

--- a/app/infrastructure/svc_engine.py
+++ b/app/infrastructure/svc_engine.py
@@ -142,6 +142,8 @@ class SvcEngine:
                     min(1800.0, float(getattr(params, "adaptive_f0_max", 1100.0))),
                 )
             ),
+            "--f0-threshold",
+            str(max(0.0, min(1.0, float(getattr(params, "f0_filter_threshold", 0.05))))),
             "--device",
             params.device or "auto",
         ]
@@ -227,6 +229,8 @@ class SvcEngine:
                     min(1800.0, float(getattr(params, "adaptive_f0_max", 1100.0))),
                 )
             ),
+            "--f0-threshold",
+            str(max(0.0, min(1.0, float(getattr(params, "f0_filter_threshold", 0.05))))),
             "--k-step",
             str(self._ratio_to_kstep(params.diffusion_ratio)),
             "--diffusion-ratio",

--- a/app/infrastructure/svc_worker.py
+++ b/app/infrastructure/svc_worker.py
@@ -64,6 +64,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--speaker", default="", help="目标说话人，留空取配置首个")
     p.add_argument("--f0", default="rmvpe", help="F0 预测器")
     p.add_argument("--f0-max", type=float, default=1100.0, help="自适应 F0 上限")
+    p.add_argument("--f0-threshold", type=float, default=0.05, help="F0 置信度过滤阈值")
     p.add_argument("--k-step", type=int, default=100, help="浅扩散步数")
     p.add_argument(
         "--diffusion-ratio",
@@ -328,7 +329,7 @@ def main() -> int:
             lgr_num=0.75,
             f0_predictor=args.f0,
             enhancer_adaptive_key=0,
-            cr_threshold=0.05,
+            cr_threshold=max(0.0, min(1.0, float(args.f0_threshold))),
             k_step=effective_k_step,
             use_spk_mix=False,
             second_encoding=False,

--- a/app/tests/test_http_api.py
+++ b/app/tests/test_http_api.py
@@ -396,6 +396,10 @@ class HttpApiContractTests(unittest.TestCase):
             "ddsp_infer_steps",
             "ddsp_formant_shift",
             "auto_high_pitch_guard",
+            "high_pitch_guard_rounds",
+            "high_pitch_threshold",
+            "f0_filter_threshold",
+            "manual_params_enabled",
         }
 
         self.assertEqual(set(inference), expected_inference_fields)

--- a/app/tests/test_vocal_enhancement.py
+++ b/app/tests/test_vocal_enhancement.py
@@ -378,6 +378,32 @@ def test_model_dropout_probe_ignores_normal_render_and_source_pause(tmp_path: Pa
     assert ConversionService._detect_model_dropout(source, output, 760.0) is None
 
 
+def test_model_dropout_probe_ignores_loud_render_without_trackable_f0(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 760.0 * time_axis)).astype(np.float32)
+    # A loud harmonic/noise-like render can make the lightweight pitch probe
+    # return F0=0 even though the syllable is not muted.
+    output_audio = (0.24 * np.sin(2.0 * np.pi * 7000.0 * time_axis)).astype(np.float32)
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "source.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, output_audio)
+
+    assert ConversionService._detect_model_dropout(source, output, 760.0) is None
+
+
 def test_model_dropout_probe_finds_intermittent_high_note_mutes(tmp_path: Path) -> None:
     import wave
 
@@ -407,6 +433,33 @@ def test_model_dropout_probe_finds_intermittent_high_note_mutes(tmp_path: Path) 
     issue = ConversionService._detect_model_dropout(source, output, 760.0)
     assert issue is not None
     assert 0.70 < issue["start"] < 0.95
+    assert issue["duration"] > 0.04
+
+
+def test_model_dropout_probe_finds_breathy_high_note_with_f0_present(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 760.0 * time_axis)).astype(np.float32)
+    output_audio = source_audio.copy()
+    output_audio[(time_axis >= 0.80) & (time_axis < 1.20)] *= 0.48
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "source.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, output_audio)
+
+    issue = ConversionService._detect_model_dropout(source, output, 760.0)
+    assert issue is not None
     assert issue["duration"] > 0.04
 
 
@@ -558,6 +611,57 @@ def test_dropout_recovery_keeps_default_render_when_no_dropout(tmp_path: Path) -
     assert guard_applied is False
 
 
+def test_dropout_recovery_is_fully_disabled_when_high_pitch_guard_is_off(
+    tmp_path: Path,
+) -> None:
+    service = ConversionService.__new__(ConversionService)
+    source = tmp_path / "source.wav"
+    output = tmp_path / "converted_raw.wav"
+    source.write_bytes(b"source")
+    calls: list[tuple[Path, Path]] = []
+    detection_calls = 0
+
+    def infer(vocals: Path, target: Path) -> None:
+        calls.append((vocals, target))
+        target.write_bytes(b"ordinary-render")
+
+    def detect(*_args) -> dict[str, float]:
+        nonlocal detection_calls
+        detection_calls += 1
+        return {"start": 0.5, "end": 0.8, "source_f0_hz": 920.0}
+
+    service._log = lambda *_args: None
+    service._detect_model_dropout = detect
+    service._prepare_high_pitch_guard = lambda *_args: (_ for _ in ()).throw(
+        AssertionError("high-pitch guard must not prepare input when disabled")
+    )
+    service._restore_high_pitch_guard = lambda *_args: (_ for _ in ()).throw(
+        AssertionError("high-pitch guard must not restore output when disabled")
+    )
+
+    rendered, history, guard_applied = service._infer_with_dropout_recovery(
+        engine=types.SimpleNamespace(),
+        model={},
+        source=source,
+        output=output,
+        params=InferenceParams(
+            high_pitch_threshold=800.0,
+            auto_high_pitch_guard=False,
+            high_pitch_guard_rounds=8,
+        ),
+        duration=2.0,
+        log_file=tmp_path / "run.log",
+        allow_recovery=True,
+        infer=infer,
+    )
+
+    assert rendered == output
+    assert calls == [(source, output)]
+    assert detection_calls == 0
+    assert history == []
+    assert guard_applied is False
+
+
 def test_high_pitch_guard_rounds_are_opt_in_and_clamped() -> None:
     from domain import InferenceParams
 
@@ -587,6 +691,23 @@ def test_guard_drop_escalates_only_after_high_note_retry_still_exceeds_range() -
     assert ConversionService._guard_semitones_for_retry(
         620.0, {"source_f0_hz": 900.0}
     ) == 12
+
+
+def test_confirmed_guard_regions_keep_phrase_context_without_global_expansion() -> None:
+    regions = ConversionService._confirmed_guard_regions(
+        {"bad_regions": [{"start": 61.0, "end": 61.2}, {"start": 62.0, "end": 62.3}]}
+    )
+    assert regions is not None
+    assert regions[0][0] == pytest.approx(60.1)
+    assert regions[0][1] == pytest.approx(63.2)
+    separated = ConversionService._confirmed_guard_regions(
+        {"bad_regions": [{"start": 54.0, "end": 54.2}]},
+        existing=[(60.0, 63.0)],
+    )
+    assert separated is not None
+    assert separated[0][0] == pytest.approx(53.1)
+    assert separated[0][1] == pytest.approx(55.1)
+    assert separated[1] == pytest.approx((60.0, 63.0))
 
 
 def test_dropout_recovery_uses_guard_only_after_verified_failure_and_falls_back(

--- a/app/tests/test_vocal_enhancement.py
+++ b/app/tests/test_vocal_enhancement.py
@@ -194,7 +194,12 @@ def test_conversion_service_reads_all_enhancement_controls() -> None:
 
 
 def test_high_range_profile_adapts_f0_and_transient_protection(tmp_path: Path) -> None:
-    params = InferenceParams(f0_method="harvest", protect=0.33, filter_radius=5)
+    params = InferenceParams(
+        f0_method="harvest",
+        protect=0.33,
+        filter_radius=5,
+        manual_params_enabled=True,
+    )
     logger = types.SimpleNamespace(_log=lambda *_args: None)
     fcpe_model = tmp_path / "pretrain" / "fcpe.pt"
     fcpe_model.parent.mkdir(parents=True)
@@ -248,6 +253,483 @@ def test_high_range_adaptation_is_noop_when_guard_disabled(tmp_path: Path) -> No
     assert params.filter_radius == 5
     assert params.protect == 0.33
     assert not hasattr(params, "adaptive_f0_max")
+
+
+def test_default_mode_keeps_original_inference_defaults_on_high_pitch_input(tmp_path: Path) -> None:
+    params = InferenceParams(f0_method="harvest", protect=0.33, filter_radius=5)
+    logger = types.SimpleNamespace(_log=lambda *_args: None)
+
+    ConversionService._adapt_high_range(
+        logger,
+        params,
+        {
+            "high_pitch": True,
+            "high_frequency": True,
+            "p95_f0_hz": 980.0,
+            "high_band_ratio": 0.12,
+            "recommended_f0_max": 1480.0,
+        },
+        tmp_path / "run.log",
+        "rvc",
+    )
+
+    assert params.f0_method == "harvest"
+    assert params.filter_radius == 5
+    assert params.protect == 0.33
+    assert not hasattr(params, "adaptive_f0_max")
+    assert (
+        ConversionService._model_high_pitch_threshold(
+            params,
+            {"metadata": {"f0_max_hz": 500.0}},
+            "rvc",
+        )
+        == 800.0
+    )
+
+
+def test_peak_f0_probe_prefers_model_backed_sidecar(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate, dtype=np.float64) / sample_rate
+    source = tmp_path / "infer_input.wav"
+    pcm = np.asarray(0.2 * np.sin(2.0 * np.pi * 680.0 * time_axis) * 32767.0, dtype="<i2")
+    with wave.open(str(source), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(pcm.tobytes())
+    np.save(tmp_path / "f0.npy", np.full(50, 680.0, dtype=np.float32))
+
+    assert 675.0 < ConversionService._estimate_peak_f0(source) < 685.0
+
+
+def test_peak_f0_probe_still_detects_sustained_high_note_without_sidecar(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source = tmp_path / "vocal.wav"
+    pcm = np.asarray(0.2 * np.sin(2.0 * np.pi * 920.0 * time_axis) * 32767.0, dtype="<i2")
+    with wave.open(str(source), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(pcm.tobytes())
+
+    assert ConversionService._estimate_peak_f0(source) >= 800.0
+
+
+def test_model_dropout_probe_finds_only_voiced_collapsed_high_note(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 760.0 * time_axis)).astype(np.float32)
+    output_audio = source_audio.copy()
+    output_audio[(time_axis >= 0.80) & (time_axis < 1.20)] = 0.0
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "source.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, output_audio)
+
+    issue = ConversionService._detect_model_dropout(source, output, 760.0)
+    assert issue is not None
+    assert 0.70 < issue["start"] < 0.90
+    assert 700.0 < issue["source_f0_hz"] < 820.0
+    assert ConversionService._next_dropout_threshold(760.0, issue) < 760.0
+
+
+def test_model_dropout_probe_ignores_normal_render_and_source_pause(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 760.0 * time_axis)).astype(np.float32)
+    source_audio[(time_axis >= 0.80) & (time_axis < 1.20)] = 0.0
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "source.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, source_audio)
+
+    assert ConversionService._detect_model_dropout(source, output, 760.0) is None
+
+    # A model may produce a valid render with a lower global gain.  That is
+    # not a local high-note dropout and must not trigger a guarded re-inference.
+    write_wav(output, source_audio * 0.06)
+    assert ConversionService._detect_model_dropout(source, output, 760.0) is None
+
+
+def test_model_dropout_probe_finds_intermittent_high_note_mutes(tmp_path: Path) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 760.0 * time_axis)).astype(np.float32)
+    output_audio = source_audio.copy()
+    # Simulate the reported failure: the same high note alternates between a
+    # valid render and a short mute instead of staying silent continuously.
+    affected = (time_axis >= 0.80) & (time_axis < 1.20)
+    alternating_mute = affected & (((time_axis - 0.80) % 0.16) < 0.08)
+    output_audio[alternating_mute] = 0.0
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "source.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, output_audio)
+
+    issue = ConversionService._detect_model_dropout(source, output, 760.0)
+    assert issue is not None
+    assert 0.70 < issue["start"] < 0.95
+    assert issue["duration"] > 0.04
+
+
+def test_model_dropout_probe_finds_short_high_note_mute_below_guard_boundary(
+    tmp_path: Path,
+) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 760.0 * time_axis)).astype(np.float32)
+    output_audio = source_audio.copy()
+    output_audio[(time_axis >= 0.82) & (time_axis < 0.90)] = 0.0
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "source.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, output_audio)
+
+    # 760 Hz is just below the default 800 Hz boundary and represents the
+    # short one-syllable dropout that the regular confirmation window misses.
+    issue = ConversionService._detect_model_dropout(source, output, 800.0)
+    assert issue is not None
+    assert 0.72 < issue["start"] < 0.95
+    assert issue["duration"] < 0.20
+
+
+def test_finished_work_cache_cleanup_preserves_editor_materials(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    editor_clip = work_dir / "editor_segments" / "model_a" / "seg_001.wav"
+    editor_clip.parent.mkdir(parents=True)
+    editor_clip.write_bytes(b"editor")
+    kept_output = work_dir / "output.wav"
+    kept_model = work_dir / "full_model_a_fix.wav"
+    kept_input = work_dir / "infer_input.wav"
+    for path in (kept_output, kept_model, kept_input):
+        path.write_bytes(b"keep")
+    retry = work_dir / "converted_raw_high_guarded_retry1.wav"
+    retry.write_bytes(b"retry")
+    (work_dir / "converted_raw_restored_retry1.regions.json").write_text("{}")
+    (work_dir / "f0.npy").write_bytes(b"f0")
+    (work_dir / "source.wav").write_bytes(b"normalized")
+    selected_stem = work_dir / "dereverb" / "selected.wav"
+    stale_stem = work_dir / "dereverb" / "stale.wav"
+    selected_stem.parent.mkdir(parents=True)
+    selected_stem.write_bytes(b"selected")
+    stale_stem.write_bytes(b"stale")
+    log_file = work_dir / "run.log"
+    work = {
+        "output_path": str(kept_output),
+        "ai_vocal_paths": [str(kept_model)],
+        "ai_segment_clips": [{"file": str(editor_clip)}],
+        "vocals_path": str(selected_stem),
+    }
+
+    service = ConversionService.__new__(ConversionService)
+    service._cleanup_finished_work_cache(work_dir, work, log_file)
+
+    assert kept_output.exists()
+    assert kept_model.exists()
+    assert kept_input.exists()
+    assert editor_clip.exists()
+    assert not retry.exists()
+    assert not (work_dir / "converted_raw_restored_retry1.regions.json").exists()
+    assert not (work_dir / "f0.npy").exists()
+    assert not (work_dir / "source.wav").exists()
+    assert selected_stem.exists()
+    assert not stale_stem.exists()
+
+
+def test_model_dropout_probe_finds_high_note_pitch_collapse_from_f0_sidecar(
+    tmp_path: Path,
+) -> None:
+    import wave
+
+    sample_rate = 16000
+    time_axis = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source_audio = (0.24 * np.sin(2.0 * np.pi * 900.0 * time_axis)).astype(np.float32)
+    output_audio = (0.24 * np.sin(2.0 * np.pi * 220.0 * time_axis)).astype(np.float32)
+
+    def write_wav(path: Path, values: np.ndarray) -> None:
+        pcm = np.asarray(np.clip(values, -1.0, 1.0) * 32767.0, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+    source = tmp_path / "infer_input.wav"
+    output = tmp_path / "output.wav"
+    write_wav(source, source_audio)
+    write_wav(output, output_audio)
+    np.save(tmp_path / "f0.npy", np.full(100, 900.0, dtype=np.float32))
+
+    issue = ConversionService._detect_model_dropout(source, output, 800.0)
+
+    assert issue is not None
+    assert issue["source_f0_hz"] > 850.0
+    assert issue["output_f0_hz"] < 300.0
+
+
+def test_dropout_recovery_keeps_default_render_when_no_dropout(tmp_path: Path) -> None:
+    service = ConversionService.__new__(ConversionService)
+    source = tmp_path / "source.wav"
+    output = tmp_path / "converted_raw.wav"
+    source.write_bytes(b"source")
+    calls: list[tuple[Path, Path]] = []
+
+    def infer(vocals: Path, target: Path) -> None:
+        calls.append((vocals, target))
+        target.write_bytes(b"ordinary-render")
+
+    service._log = lambda *_args: None
+    service._detect_model_dropout = lambda *_args: None
+
+    rendered, history, guard_applied = service._infer_with_dropout_recovery(
+        engine=types.SimpleNamespace(),
+        model={},
+        source=source,
+        output=output,
+        params=InferenceParams(high_pitch_threshold=800.0),
+        duration=2.0,
+        log_file=tmp_path / "run.log",
+        allow_recovery=True,
+        infer=infer,
+    )
+
+    assert rendered == output
+    assert output.read_bytes() == b"ordinary-render"
+    assert calls == [(source, output)]
+    assert history == [
+        {
+            "attempt": 1,
+            "threshold": 800.0,
+            "issue": None,
+            "guard_applied": False,
+            "input": "original",
+        }
+    ]
+    assert guard_applied is False
+
+
+def test_high_pitch_guard_rounds_are_opt_in_and_clamped() -> None:
+    from domain import InferenceParams
+
+    assert InferenceParams.from_dict({"high_pitch_guard_rounds": 99}).high_pitch_guard_rounds == 8
+    assert InferenceParams.from_dict({"highPitchGuardRounds": -2}).high_pitch_guard_rounds == 0
+    assert (
+        ConversionService._high_pitch_guard_rounds(
+            InferenceParams(manual_params_enabled=False, high_pitch_guard_rounds=0)
+        )
+        == ConversionService._DROPOUT_RECOVERY_MAX_ATTEMPTS - 1
+    )
+    assert (
+        ConversionService._high_pitch_guard_rounds(
+            InferenceParams(manual_params_enabled=True, high_pitch_guard_rounds=2)
+        )
+        == 2
+    )
+
+
+def test_dropout_recovery_uses_guard_only_after_verified_failure_and_falls_back(
+    tmp_path: Path,
+) -> None:
+    service = ConversionService.__new__(ConversionService)
+    source = tmp_path / "source.wav"
+    output = tmp_path / "converted_raw.wav"
+    source.write_bytes(b"source")
+    calls: list[tuple[Path, Path]] = []
+    issue = {
+        "start": 0.8,
+        "end": 1.1,
+        "source_f0_hz": 920.0,
+        "source_rms": 0.2,
+        "output_rms": 0.01,
+        "duration": 0.3,
+    }
+    detections = iter([issue, issue, issue, issue])
+
+    def infer(vocals: Path, target: Path) -> None:
+        calls.append((vocals, target))
+        target.write_bytes(b"guarded-render" if "dropout_retry" in target.name else b"ordinary-render")
+
+    def prepare(
+        src: Path,
+        destination: Path,
+        *_args,
+    ) -> tuple[Path, bool]:
+        destination.write_bytes(b"guarded-input")
+        return destination, True
+
+    def restore(
+        _src: Path,
+        destination: Path,
+        *_args,
+    ) -> Path:
+        destination.write_bytes(b"restored-render")
+        return destination
+
+    service._log = lambda *_args: None
+    service._detect_model_dropout = lambda *_args: next(detections)
+    service._prepare_high_pitch_guard = prepare
+    service._restore_high_pitch_guard = restore
+
+    rendered, history, guard_applied = service._infer_with_dropout_recovery(
+        engine=types.SimpleNamespace(),
+        model={},
+        source=source,
+        output=output,
+        params=InferenceParams(high_pitch_threshold=800.0),
+        duration=2.0,
+        log_file=tmp_path / "run.log",
+        allow_recovery=True,
+        infer=infer,
+    )
+
+    assert rendered == output
+    assert output.read_bytes() == b"ordinary-render"
+    assert calls[0] == (source, output)
+    assert calls[1][0].name == "converted_raw_high_guarded_retry1.wav"
+    assert history[0]["input"] == "original"
+    assert history[-1]["issue"] is not None
+    assert guard_applied is False
+
+
+def test_guarded_retry_merge_preserves_non_high_baseline_audio(tmp_path: Path) -> None:
+    import json
+    import wave
+
+    sample_rate = 16000
+    frames = sample_rate
+    baseline = tmp_path / "baseline.wav"
+    guarded = tmp_path / "guarded.wav"
+    merged = tmp_path / "merged.wav"
+    report = tmp_path / "regions.json"
+
+    def write(path: Path, value: int) -> None:
+        audio = np.full((frames, 2), value, dtype="<i2")
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(2)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(audio.tobytes())
+
+    write(baseline, 1000)
+    write(guarded, 2000)
+    report.write_text(
+        json.dumps(
+            {
+                "regions": [
+                    {"start": 0.4, "end": 0.6},
+                    {"start": 0.75, "end": 0.85},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert ConversionService._merge_guarded_regions(
+        baseline,
+        guarded,
+        merged,
+        report,
+        only_regions=[(0.35, 0.65)],
+    ) == merged
+    with wave.open(str(merged), "rb") as handle:
+        values = np.frombuffer(handle.readframes(frames), dtype="<i2").reshape(-1, 2)
+    assert np.all(values[int(0.1 * sample_rate)] == 1000)
+    assert np.all(values[int(0.5 * sample_rate)] == 2000)
+    assert np.all(values[int(0.8 * sample_rate)] == 1000)
+    assert np.all(values[int(0.9 * sample_rate)] == 1000)
+
+
+def test_formant_guard_bridges_short_high_note_boundary_dip() -> None:
+    intervals = formant_pitch_worker._high_intervals(
+        [(0.40, 830.0), (0.44, 780.0), (0.48, 835.0)],
+        800.0,
+        0.0,
+        1.0,
+    )
+
+    assert intervals
+    assert intervals[0][0] < 0.40 < intervals[0][1]
+    assert intervals[0][1] > 0.48
+
+
+def test_formant_guard_pitch_tier_uses_smooth_boundary_fades() -> None:
+    intervals = [(1.0, 1.4)]
+    before = formant_pitch_worker._region_weight_at(0.90, intervals)
+    entering = formant_pitch_worker._region_weight_at(0.98, intervals)
+    inside = formant_pitch_worker._region_weight_at(1.10, intervals)
+    leaving = formant_pitch_worker._region_weight_at(1.44, intervals)
+
+    assert before == 0.0
+    assert 0.0 < entering < 1.0
+    assert inside == 1.0
+    assert 0.0 < leaving < 1.0
+
+
+def test_realtime_high_pitch_guard_uses_stable_default_and_honors_manual_value() -> None:
+    from application.realtime_cover_service import RealtimeCoverService
+
+    assert (
+        RealtimeCoverService._model_high_pitch_threshold(
+            InferenceParams(), {"framework": "seed-vc", "metadata": {"f0_max_hz": 1200}}
+        )
+        == 720.0
+    )
+    assert (
+        RealtimeCoverService._model_high_pitch_threshold(
+            InferenceParams(high_pitch_threshold=610.0), {"framework": "rvc"}
+        )
+        == 610.0
+    )
 
 
 def test_audio_profile_detects_high_pitch_and_high_band() -> None:

--- a/app/tests/test_vocal_enhancement.py
+++ b/app/tests/test_vocal_enhancement.py
@@ -577,6 +577,18 @@ def test_high_pitch_guard_rounds_are_opt_in_and_clamped() -> None:
     )
 
 
+def test_guard_drop_escalates_only_after_high_note_retry_still_exceeds_range() -> None:
+    assert ConversionService._guard_semitones_for_retry(
+        730.0, {"source_f0_hz": 747.0}
+    ) == 7
+    assert ConversionService._guard_semitones_for_retry(
+        670.0, {"source_f0_hz": 760.0}
+    ) == 9
+    assert ConversionService._guard_semitones_for_retry(
+        620.0, {"source_f0_hz": 900.0}
+    ) == 12
+
+
 def test_dropout_recovery_uses_guard_only_after_verified_failure_and_falls_back(
     tmp_path: Path,
 ) -> None:
@@ -639,6 +651,71 @@ def test_dropout_recovery_uses_guard_only_after_verified_failure_and_falls_back(
     assert history[0]["input"] == "original"
     assert history[-1]["issue"] is not None
     assert guard_applied is False
+
+
+def test_dropout_recovery_stops_when_retry_detects_failure_outside_guard_scope(
+    tmp_path: Path,
+) -> None:
+    from domain import InferenceParams
+
+    service = ConversionService.__new__(ConversionService)
+    source = tmp_path / "source.wav"
+    output = tmp_path / "converted_raw.wav"
+    source.write_bytes(b"source")
+    first_issue = {
+        "start": 1.0,
+        "end": 1.3,
+        "source_f0_hz": 920.0,
+        "source_rms": 0.2,
+        "output_rms": 0.01,
+        "bad_frames": 30,
+        "bad_regions": [{"start": 1.0, "end": 1.3}],
+    }
+    outside_issue = {
+        "start": 5.0,
+        "end": 5.2,
+        "source_f0_hz": 701.0,
+        "source_rms": 0.2,
+        "output_rms": 0.01,
+        "bad_frames": 10,
+        "bad_regions": [{"start": 5.0, "end": 5.2}],
+    }
+    detections = iter([first_issue, outside_issue])
+    calls: list[tuple[Path, Path]] = []
+
+    def infer(vocals: Path, target: Path) -> None:
+        calls.append((vocals, target))
+        target.write_bytes(b"render")
+
+    def prepare(src: Path, destination: Path, *_args) -> tuple[Path, bool]:
+        destination.write_bytes(b"guarded-input")
+        return destination, True
+
+    def restore(_src: Path, destination: Path, *_args) -> Path:
+        destination.write_bytes(b"restored-render")
+        return destination
+
+    service._log = lambda *_args: None
+    service._detect_model_dropout = lambda *_args: next(detections)
+    service._prepare_high_pitch_guard = prepare
+    service._restore_high_pitch_guard = restore
+
+    rendered, history, guard_applied = service._infer_with_dropout_recovery(
+        engine=types.SimpleNamespace(),
+        model={},
+        source=source,
+        output=output,
+        params=InferenceParams(high_pitch_threshold=800.0),
+        duration=2.0,
+        log_file=tmp_path / "run.log",
+        allow_recovery=True,
+        infer=infer,
+    )
+
+    assert rendered.name == "converted_raw_restored_retry1.wav"
+    assert guard_applied is True
+    assert len(history) == 2
+    assert len(calls) == 2
 
 
 def test_guarded_retry_merge_preserves_non_high_baseline_audio(tmp_path: Path) -> None:
@@ -773,6 +850,19 @@ def test_formant_guard_keeps_hysteresis_notes_untouched_without_scope() -> None:
     assert formant_pitch_worker._high_intervals(
         [(0.50, 670.0), (0.54, 690.0)], 720.0, 0.0, 1.0
     ) == []
+
+
+def test_formant_guard_applies_hysteresis_fallback_per_scope() -> None:
+    intervals = formant_pitch_worker._high_intervals(
+        [(0.50, 800.0), (0.54, 820.0), (0.80, 670.0), (0.84, 690.0)],
+        720.0,
+        0.0,
+        1.0,
+        allowed_regions=[(0.45, 0.60), (0.75, 0.90)],
+    )
+    assert len(intervals) == 2
+    assert intervals[0][0] < 0.50 < intervals[0][1]
+    assert intervals[1][0] < 0.80 < intervals[1][1]
 
 
 def test_formant_guard_rejects_collapsed_render(tmp_path: Path, monkeypatch) -> None:

--- a/app/tests/test_vocal_enhancement.py
+++ b/app/tests/test_vocal_enhancement.py
@@ -758,6 +758,23 @@ def test_formant_guard_ignores_isolated_pitch_tracker_spikes() -> None:
     assert intervals[0][0] < 0.50 < intervals[0][1]
 
 
+def test_formant_guard_accepts_notes_in_detector_hysteresis_band() -> None:
+    intervals = formant_pitch_worker._high_intervals(
+        [(0.50, 670.0), (0.54, 690.0)],
+        720.0,
+        0.0,
+        1.0,
+        allowed_regions=[(0.45, 0.60)],
+    )
+    assert intervals
+
+
+def test_formant_guard_keeps_hysteresis_notes_untouched_without_scope() -> None:
+    assert formant_pitch_worker._high_intervals(
+        [(0.50, 670.0), (0.54, 690.0)], 720.0, 0.0, 1.0
+    ) == []
+
+
 def test_formant_guard_rejects_collapsed_render(tmp_path: Path, monkeypatch) -> None:
     import wave
 

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -43,6 +43,21 @@ function Require-File([string]$Path, [string]$Label) {
   }
 }
 
+function Require-WorkerContract([string]$Path, [string]$Label, [string[]]$Required, [string[]]$Forbidden) {
+  Require-File $Path $Label
+  $content = Get-Content -LiteralPath $Path -Raw
+  foreach ($marker in $Required) {
+    if ($content -notmatch [regex]::Escape($marker)) {
+      throw "$Label has an unexpected implementation: missing '$marker' in $Path"
+    }
+  }
+  foreach ($marker in $Forbidden) {
+    if ($content -match [regex]::Escape($marker)) {
+      throw "$Label has been replaced by another worker: found '$marker' in $Path"
+    }
+  }
+}
+
 function Require-FileSize([string]$Path, [long]$MinimumBytes, [string]$Label) {
   Require-File $Path $Label
   $item = Get-Item -LiteralPath $Path
@@ -325,6 +340,16 @@ $workerFiles = @(
 foreach ($worker in $workerFiles) {
   Require-File (Join-Path $Root "app\infrastructure\$worker") "Worker source $worker"
 }
+Require-WorkerContract `
+  (Join-Path $Root "app\infrastructure\f0_worker.py") `
+  "F0 worker source" `
+  @("--out-npy", "F0_OK") `
+  @("--high-threshold", "FORMANT_PITCH_OK")
+Require-WorkerContract `
+  (Join-Path $Root "app\infrastructure\formant_pitch_worker.py") `
+  "Formant pitch worker source" `
+  @("--high-threshold", "FORMANT_PITCH_OK") `
+  @("--out-npy", "F0_OK")
 Require-File (Join-Path $Root "docs\release-notes\release_notes_v030.md") "v0.0.30 release notes"
 Require-File (Join-Path $Root "docs\api.md") "FastAPI integration guide"
 Require-File (Join-Path $Root "install\configure_user_env.py") "User environment helper"
@@ -482,6 +507,16 @@ Require-File (Join-Path $stagedInternal "web\dist\index.html") "Staged frontend 
 foreach ($worker in $workerFiles) {
   Require-File (Join-Path $stagedInternal "infrastructure\$worker") "Staged worker $worker"
 }
+Require-WorkerContract `
+  (Join-Path $stagedInternal "infrastructure\f0_worker.py") `
+  "Staged F0 worker" `
+  @("--out-npy", "F0_OK") `
+  @("--high-threshold", "FORMANT_PITCH_OK")
+Require-WorkerContract `
+  (Join-Path $stagedInternal "infrastructure\formant_pitch_worker.py") `
+  "Staged formant pitch worker" `
+  @("--high-threshold", "FORMANT_PITCH_OK") `
+  @("--out-npy", "F0_OK")
 
 # 3) Build native JUCE VST3 host and stage it next to the app exe.
 if (-not $SkipJuceHostBuild) {

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -260,11 +260,17 @@ export const api = {
       mock.toggleModelFavorite(id),
     ),
 
+  renameModel: (id: string, name: string) =>
+    invoke<boolean>('rename_model', [id, name], () => mock.renameModel(id, name)),
+
   pickAudioFile: () =>
     invoke<string | null>('pick_audio_file', [], () => mock.pickAudioFile()),
 
   pickAudioFiles: () =>
     invoke<string[]>('pick_audio_files', [], () => mock.pickAudioFiles()),
+
+  importAudioData: (name: string, data: string) =>
+    invoke<string | null>('import_audio_data', [name, data], () => mock.importAudioData(name, data)),
 
   pickLyricsFile: () =>
     invoke<LyricsFileResult>('pick_lyrics_file', [], () => mock.pickLyricsFile()),

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -885,6 +885,13 @@ export const mock = {
     m.favorite = !m.favorite
     return { ...m }
   },
+  renameModel(id: string, name: string): boolean {
+    const model = mockModels.find((item) => item.id === id)
+    const normalized = String(name || '').trim().replace(/\s+/g, ' ')
+    if (!model || !normalized || normalized.length > 120) return false
+    model.name = normalized
+    return true
+  },
   pickAudioFile(): string | null {
     return `C:/music/示例歌曲_${Date.now()}.mp3`
   },
@@ -893,6 +900,9 @@ export const mock = {
       `C:/music/批量歌曲_A_${Date.now()}.mp3`,
       `C:/music/批量歌曲_B_${Date.now()}.mp3`,
     ]
+  },
+  importAudioData(name: string, _data = ''): string {
+    return `C:/music/${fileName(name)}`
   },
   pickLyricsFile(): Promise<LyricsFileResult> {
     return browserPickTextFile('.lrc,.txt')

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -268,6 +268,12 @@ export interface InferenceParams {
   speaker?: string
   /** 高音保护：超出模型可靠音域时降调翻唱，再升回原调并补偿响度。 */
   auto_high_pitch_guard?: boolean
+  /** 高音保护重试轮次。 */
+  high_pitch_guard_rounds?: number
+  /** F0 过滤阈值（0~1）。 */
+  f0_filter_threshold?: number
+  /** 是否启用全参数手动调整；关闭时使用软件默认值。 */
+  manual_params_enabled?: boolean
 }
 
 export interface WorkDTO {

--- a/web/src/components/onboarding/FirstUseGuide.vue
+++ b/web/src/components/onboarding/FirstUseGuide.vue
@@ -1,0 +1,365 @@
+<template>
+  <Teleport to="body">
+    <Transition name="interactive-guide">
+      <div
+        v-if="visible"
+        class="interactive-guide"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="interactive-guide-title"
+        tabindex="-1"
+        @keydown.esc="skip"
+      >
+        <div v-if="hasTarget" class="guide-focus" :style="focusStyle" aria-hidden="true"></div>
+
+        <aside class="guide-callout" :class="{ 'is-centered': !hasTarget }" :style="calloutStyle">
+          <header class="callout-header">
+            <div class="callout-section"><el-icon><Guide /></el-icon>{{ activeStep.section }}</div>
+            <div class="callout-count">{{ currentStep + 1 }} / {{ steps.length }}</div>
+            <button type="button" class="callout-close" title="跳过引导" aria-label="跳过引导" @click="skip">
+              <el-icon><Close /></el-icon>
+            </button>
+          </header>
+
+          <div class="callout-heading">
+            <div class="callout-icon"><el-icon><component :is="activeStep.icon" /></el-icon></div>
+            <div class="callout-heading-copy">
+              <p class="callout-target">正在查看 · {{ activeStep.targetLabel }}</p>
+              <h1 id="interactive-guide-title">{{ activeStep.title }}</h1>
+            </div>
+          </div>
+          <p class="callout-description">{{ activeStep.description }}</p>
+
+          <div class="callout-details">
+            <div v-for="detail in activeStep.details" :key="detail.label" class="callout-detail">
+              <strong>{{ detail.label }}</strong>
+              <span>{{ detail.value }}</span>
+            </div>
+          </div>
+          <p v-if="locating" class="callout-locating"><i></i>正在打开页面并定位组件…</p>
+          <p v-else-if="!hasTarget" class="callout-locating is-warning"><i></i>当前页面暂未找到该组件，可先阅读说明继续</p>
+
+          <footer class="callout-footer">
+            <button type="button" class="guide-skip" @click="skip">跳过引导</button>
+            <div class="guide-actions">
+              <button v-if="currentStep > 0" type="button" class="guide-back" :disabled="locating" @click="goToStep(currentStep - 1)">上一步</button>
+              <button type="button" class="guide-next" :disabled="locating" @click="next">
+                {{ currentStep === steps.length - 1 ? '完成并开始使用' : '下一步' }}
+                <el-icon><ArrowRight /></el-icon>
+              </button>
+            </div>
+          </footer>
+        </aside>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ArrowRight, Close, FolderOpened, Guide, MagicStick, Microphone, Operation, Setting, UploadFilled } from '@element-plus/icons-vue'
+
+defineOptions({ name: 'FirstUseGuide' })
+
+type GuidePlacement = 'top' | 'right' | 'bottom' | 'left'
+interface GuideDetail { label: string; value: string }
+interface GuideStep {
+  section: string
+  targetLabel: string
+  title: string
+  description: string
+  details: GuideDetail[]
+  route: string
+  selector: string
+  placement: GuidePlacement
+  icon: typeof Microphone
+  prepare?: 'multi' | 'multi-timeline' | 'enhancement' | 'open-player'
+}
+
+const STORAGE_KEY = 'xb-first-use-guide-v3'
+const router = useRouter()
+const route = useRoute()
+const visible = ref(false)
+const locating = ref(false)
+const currentStep = ref(0)
+const hasTarget = ref(false)
+const targetRect = ref<DOMRect | null>(null)
+let focusRaf = 0
+
+const steps: GuideStep[] = [
+  { section: '首页 · 01', targetLabel: 'AI 翻唱快捷入口', title: '从这里开始一次完整翻唱', description: 'AI 翻唱工作台负责导入歌曲、选择音色、设置推理并生成作品。点击快捷入口进入空白工作台；从首页拖入音频则会把该文件一并带入。', details: [{ label: '点击卡片', value: '进入空白工作台' }, { label: '拖拽音频', value: '自动跳转并预填这首歌' }], route: '/', selector: '[data-guide="home-ai-cover"]', placement: 'right', icon: Microphone },
+  { section: '首页 · 02', targetLabel: '首页音频拖拽区', title: '拖入音频会自动带入翻唱', description: '把歌曲拖到首页这个区域，软件会校验格式和大小，然后跳转到 AI 翻唱并显示刚才的文件。直接点击区域仍然只是打开空白工作台。', details: [{ label: '格式', value: 'MP3、WAV、FLAC、M4A、OGG、AAC' }, { label: '限制', value: '单个文件不超过 50MB' }], route: '/', selector: '[data-guide="home-dropzone"]', placement: 'bottom', icon: UploadFilled },
+  { section: '翻唱工作台 · 03', targetLabel: '单模型 / 多模型模式', title: '先决定整首歌还是逐句分配', description: '单模型适合整首歌保持一个音色，步骤少、最容易成功。多模型会显示歌词时间轴，可以按句选择不同音色，也可以多选形成合唱。', details: [{ label: '单模型', value: '整首统一音色，适合快速生成' }, { label: '多模型', value: '逐句分配模型，适合角色切换与和声' }, { label: '切换', value: '已填写的歌曲与常用参数会保留' }], route: '/create', selector: '[data-guide="cover-mode"]', placement: 'right', icon: Operation },
+  { section: '翻唱工作台 · 04', targetLabel: '歌曲导入区', title: '点击选择或拖拽歌曲', description: '工作台的导入区与首页行为一致。你可以点击选择本地文件，也可以直接拖入；已下载的曲库素材会列在下方，一键即可使用。', details: [{ label: '本地文件', value: '桌面端选择路径，网页端读取文件' }, { label: '已下载', value: '从资源获取页下载的歌曲可直接复用' }, { label: '试听', value: '导入后先确认歌曲和时长再推理' }], route: '/create', selector: '[data-guide="cover-upload"]', placement: 'right', icon: UploadFilled },
+  { section: '翻唱工作台 · 05', targetLabel: '高级功能开关', title: '先选择需要的工作流', description: '这里集中放置前期处理和歌声增强等工作流。普通用户可以保持默认关闭；需要更细的声音处理时再进入对应模块。', details: [{ label: '前期处理', value: '先分离人声、去混响，再送进模型' }, { label: '歌声增强', value: '生成前做自然修音与动态处理' }, { label: '普通流程', value: '不打开高级功能也可以直接生成' }], route: '/create', selector: '[data-guide="cover-workflow"]', placement: 'right', icon: Setting },
+  { section: '前期人声处理 · 06', targetLabel: '前期人声处理', title: '在推理前清理输入人声', description: '打开前期处理后，软件会先把歌曲拆成人声和伴奏。干净的人声能减少伴奏串音，让后面的音高检测和音色转换更稳定。', details: [{ label: '关闭', value: '直接使用原始音频，速度最快' }, { label: '开启', value: '先分离再进入翻唱流水线' }, { label: '注意', value: '处理本身会增加耗时，先试听结果再决定' }], route: '/create', selector: '[data-guide="preprocess"]', placement: 'right', icon: MagicStick },
+  { section: '前期人声处理 · 07', targetLabel: '分离引擎选择', title: '按环境选择 UVR 或 PyMSS', description: 'UVR 适合已有本地环境的快速分离；PyMSS 可以使用已下载的专用分离或去混响模型。先选引擎，再选具体模型，状态提示会告诉你是否可用。', details: [{ label: 'UVR', value: 'MDX-Net、Demucs v4、VR Arch 等通用方案' }, { label: 'PyMSS', value: '可下载人声分离与去混响模型' }, { label: '去混响', value: '可额外开启，改善房间声和尾音' }], route: '/create', selector: '[data-guide="preprocess-engine"], [data-guide="preprocess"]', placement: 'bottom', icon: FolderOpened },
+  { section: '翻唱工作台 · 08', targetLabel: '模型选择区', title: '选择适合的音色模型', description: '模型卡片会显示框架、采样率和类型。先按框架筛选，再点击模型。模型的音域配置会参与高音保护，不同模型不会共用一个固定阈值。', details: [{ label: '筛选', value: '按 So-VITS-SVC、RVC、SeedVC、DDSP-SVC 等框架过滤' }, { label: '单模型', value: '点击一张卡片作为整首歌曲的音色' }, { label: '多模型', value: '勾选多张卡片后按歌词分配' }], route: '/create', selector: '[data-guide="model-select"]', placement: 'right', icon: FolderOpened },
+  { section: '单模型推理 · 09', targetLabel: '推理参数面板', title: '默认模式先调常用参数', description: '关闭全参数时，变调、F0 算法、设备、检索率、响度混合、保护、滤波半径等常用参数仍然可调。软件默认值保持原有推理效果，隐藏的高级值不会污染本次运行。', details: [{ label: '变调', value: '按男女声或歌曲音域做半音级调整' }, { label: 'F0 / 设备', value: '选择音高算法和 CPU / GPU 推理设备' }, { label: 'RVC 参数', value: '检索率、响度混合、保护、滤波半径、版本' }], route: '/create', selector: '[data-guide="inference-params"]', placement: 'right', icon: Setting },
+  { section: '单模型推理 · 10', targetLabel: '主模型 / 扩散模型比例', title: '理解主模型和浅扩散的分工', description: '这个比例决定主模型路径与浅扩散路径对成品的贡献。它不是“越大越好”，而是速度、音色稳定性、细节、显存之间的取舍。', details: [{ label: '主模型高', value: '速度快、音色轮廓稳定、显存压力较小' }, { label: '浅扩散高', value: '细节与自然度通常更丰富，但更慢且更吃显存' }, { label: '调法', value: '先用默认值，出现毛刺或细节不足时小步调整' }], route: '/create', selector: '[data-guide="ratio-control"]', placement: 'bottom', icon: MagicStick },
+  { section: '单模型推理 · 11', targetLabel: '全参数手动调整开关', title: '打开后才让高级值参与推理', description: '全参数默认关闭。关闭时目标说话人 / 音色 ID、F0 过滤阈值和手动高音起点不会发送给推理引擎；普通参数仍然有效。应用预设也不会偷偷打开开关。', details: [{ label: '默认关闭', value: '保证新手直接生成时维持原有模型效果' }, { label: '开启后', value: '显示并发送模型支持的全部高级参数' }, { label: '预设隔离', value: '预设只载入数值，开关状态由你决定' }], route: '/create', selector: '[data-guide="manual-switch"]', placement: 'bottom', icon: Setting },
+  { section: '单模型推理 · 12', targetLabel: '高音保护与 F0 阈值', title: '按模型音域保护高音', description: '高音保护先读取当前模型的音域 profile，不再用统一固定阈值。只有打开高音保护后，且全参数开关已开启，才显示可手动编辑的保护起点。', details: [{ label: '自动', value: '0 表示使用当前模型的音域配置' }, { label: '手动起点', value: '仅全参数开启 + 高音保护开启时出现' }, { label: 'F0 过滤', value: '仅全参数开启时出现，数值越高越严格' }], route: '/create', selector: '[data-guide="high-pitch-toggle"]', placement: 'bottom', icon: Microphone },
+  { section: '多模型推理 · 13', targetLabel: '多模型模式', title: '切换到逐句混合推理', description: '多模型模式会为每个已勾选模型保存独立参数。为便于完整展示，导览会临时选中示例模型并打开全参数；退出这一段后会恢复你原来的模式和开关。', details: [{ label: '适合', value: '主唱 / 和声 / 对话角色切换' }, { label: '独立保存', value: '每个模型的变调、比例和保护互不覆盖' }, { label: '合唱', value: '同一句勾选多个模型即可叠唱' }], route: '/create', selector: '[data-guide="multi-mode"]', placement: 'bottom', icon: Operation, prepare: 'multi' },
+  { section: '多模型推理 · 14', targetLabel: '逐模型参数', title: '为每个模型单独调音', description: '勾选模型后会展开它自己的参数区。普通参数一直可调；高级字段只在全参数开启时出现，并且只作用于当前模型。', details: [{ label: '音色比例', value: '每个模型可以使用不同的主模型 / 扩散比例' }, { label: '框架专属', value: 'DDSP 的 formant、SeedVC 的参考音频按框架显示' }, { label: '目标音色', value: 'So-VITS / DDSP 可填目标说话人或音色 ID' }], route: '/create', selector: '[data-guide="multi-model-params"], [data-guide="model-select"]', placement: 'right', icon: Setting, prepare: 'multi' },
+  { section: '多模型推理 · 15', targetLabel: '歌词与分句', title: '获取歌词并校准时间轴', description: '可以按歌名从曲库获取歌词，也可以导入带时间轴的 LRC / TXT。整体偏移用于把歌词和音频对齐，之后每段都能继续精修。', details: [{ label: '获取', value: '输入歌名、序号和曲库后在线获取' }, { label: '导入', value: '选择本地 .lrc 或纯文本歌词' }, { label: '偏移', value: '用滑杆整体前后移动，单位为秒' }], route: '/create', selector: '[data-guide="multi-lyrics"]', placement: 'right', icon: UploadFilled, prepare: 'multi' },
+  { section: '多模型推理 · 16', targetLabel: '多模型时间轴', title: '先弹出时间轴，再学习逐句编排', description: '时间轴只有在多模型模式完成歌词分句后才会出现。导览会临时准备一组演示分句并自动打开“放大编辑”弹窗，让你看到真实的时间轴组件；不会提交或保存演示内容。', details: [{ label: '批量指派', value: '一键把所有句子交给某个模型' }, { label: '局部编辑', value: '拖动边界、拆分、合并、撤销 / 重做' }, { label: '间奏', value: '清空模型后该段不会生成演唱' }], route: '/create', selector: '[data-guide="multi-timeline-dialog"]', placement: 'top', icon: MagicStick, prepare: 'multi-timeline' },
+  { section: '翻唱工作台 · 17', targetLabel: 'AI Vocal Enhancement 开关', title: '生成前开启 AI 歌声增强', description: '介绍这一段时，导览会临时打开 AI Vocal Enhancement，让你直接看到增强层级和控制项。离开本段或结束引导后，开关和原来的选择会自动恢复。', details: [{ label: 'Clean Voice', value: '轻量降噪、自然修音、并行轻母带' }, { label: 'Natural Voice', value: '真实细节保护、宽带校正和自然度母带' }, { label: '恢复', value: '演示结束自动恢复你进入引导前的状态' }], route: '/create', selector: '[data-guide="enhancement-toggle"]', placement: 'right', icon: MagicStick, prepare: 'enhancement' },
+  { section: '翻唱工作台 · 18', targetLabel: 'AI 增强层级与参数', title: '分别控制增强强度', description: '基础层适合快速清理，高级层会显示更多细节控制。每个参数都可以独立调整，最终效果要以人声是否自然、是否出现泵动和齿音为准。', details: [{ label: '自然修音 / 对齐', value: '改善音高稳定性和原曲节奏贴合度' }, { label: '角色共振峰', value: '保留或强化目标音色的共鸣特征' }, { label: 'EQ / 压缩 / 激励', value: '平衡频段、动态和清晰度' }, { label: 'Stereo / 响度', value: '调整空间宽度和整体动态包络' }], route: '/create', selector: '[data-guide="enhancement-levels"], [data-guide="enhancement-controls"]', placement: 'left', icon: Setting, prepare: 'enhancement' },
+  { section: '翻唱工作台 · 18', targetLabel: '预设与推理队列', title: '保存配置并管理批量推理', description: '推理生态区域可以保存、应用、删除参数预设，也能查看排队数量。批量推理会把当前模型配置加入队列，适合一次尝试多个版本。', details: [{ label: '预设', value: '保存常用普通参数和高级参数数值' }, { label: '隔离', value: '预设不会改变全参数开关' }, { label: '队列', value: '查看等待任务，避免重复点击生成' }], route: '/create', selector: '[data-guide="cover-ecosystem"]', placement: 'right', icon: FolderOpened },
+  { section: '翻唱工作台 · 19', targetLabel: '开始生成与输出预览', title: '提交任务并试听成品', description: '确认歌曲、模型和参数后开始生成。右侧会显示处理流水线；完成后可以播放、拖动进度条和导出成品，后续也可在作品库继续管理。', details: [{ label: '生成', value: '任务进入队列并显示分离、推理、增强等阶段' }, { label: '试听', value: '播放按钮与可拖动进度条支持定位副歌和高音段' }, { label: '导出', value: '选择可用格式保存当前成品' }], route: '/create', selector: '[data-guide="cover-generate"]', placement: 'top', icon: MagicStick },
+  { section: '实时翻唱 · 20', targetLabel: '播放源', title: '选择系统音频或歌曲文件', description: '实时翻唱可以监听回环 / 虚拟线路中的系统声音，也可以让软件播放一首歌曲文件并实时转换。系统模式要先选择输入和输出设备。', details: [{ label: '系统音频', value: '适合直播、播放器和麦克风回环' }, { label: '歌曲文件', value: '选择本地或已下载素材实时播放' }, { label: '设备', value: '刷新并确认输入线路、耳机或扬声器' }], route: '/create/realtime', selector: '[data-guide="realtime-source"]', placement: 'right', icon: Microphone },
+  { section: '实时翻唱 · 21', targetLabel: '实时推理参数', title: '实时模式同样支持普通与全参数', description: '实时工作台的每个模型都有独立参数。普通字段适合低延迟使用；打开全参数后才能调整 F0 过滤阈值、目标音色和高音保护起点。', details: [{ label: '低延迟', value: '先降低质量参数和块大小，确保声音连续' }, { label: '多模型', value: '实时可在已选模型间切换或叠加' }, { label: '保护', value: '高音起点仍按模型 profile 自动推断' }], route: '/create/realtime', selector: '[data-guide="realtime-params"]', placement: 'right', icon: Setting },
+  { section: '实时翻唱 · 22', targetLabel: '实时监控与播放', title: '开始、暂停并观察实时状态', description: '监控区会显示会话状态、延迟和播放控制。设备切换或参数修改前先停止会话，避免输入输出线路被占用。', details: [{ label: '开始', value: '确认设备和模型后启动实时会话' }, { label: '播放', value: '文件模式可以暂停、继续和停止' }, { label: '故障', value: '状态提示会指出设备或引擎问题' }], route: '/create/realtime', selector: '[data-guide="realtime-monitor"]', placement: 'top', icon: Microphone },
+  { section: '资源获取 · 23', targetLabel: '在线曲库搜索', title: '搜索、试听并下载歌曲素材', description: '资源获取页可以选择曲库、搜索歌名或歌手、试听结果并下载。配置 API Key 后，下载的素材会出现在翻唱工作台的已下载列表。', details: [{ label: '曲库', value: '按已配置的网易云、QQ、酷我等来源切换' }, { label: '试听', value: '先确认版本，再点击下载或去翻唱' }, { label: '设置', value: 'API Key 和会员 Cookie 只保存在本地' }], route: '/music', selector: '[data-guide="music-search"]', placement: 'bottom', icon: FolderOpened },
+  { section: '资源获取 · 24', targetLabel: '搜索结果与已下载素材', title: '把歌曲直接送入翻唱', description: '搜索结果可以单独下载，也可以下载完成后直接跳转翻唱。已下载列表支持试听、去翻唱和删除，翻唱页会复用本地路径。', details: [{ label: '去翻唱', value: '自动带入选中的歌曲和曲库信息' }, { label: '本地复用', value: '无需重复下载即可再次使用' }, { label: '清理', value: '删除只移除本地素材，不影响已生成作品' }], route: '/music', selector: '[data-guide="music-results"], [data-guide="music-downloads"]', placement: 'right', icon: UploadFilled },
+  { section: 'AI 歌声增强 · 32', targetLabel: '增强目标和原始歌曲', title: '选择要增强的成品与参考原曲', description: '增强工作台可以选择作品库里的翻唱，也可以导入已有音频。再提供原始歌曲作为音高、节奏、音色和动态校正参考。', details: [{ label: '增强目标', value: '作品库成品或本地导入音频' }, { label: '原始歌曲', value: '本地选择，或从在线曲库搜索下载' }, { label: '要求', value: '两者越对应，校正结果越可靠' }], route: '/enhancement', selector: '[data-guide="enhancement-target"], [data-guide="enhancement-original"]', placement: 'right', icon: MagicStick },
+  { section: 'AI 歌声增强 · 33', targetLabel: '增强参数与任务', title: '选择层级、调整强度并提交', description: '基础层适合快速清理，高级层会显示更多 AI EQ、压缩器、激励、立体声和响度包络。提交后在右侧监控任务进度，完成后可播放成品。', details: [{ label: '层级', value: 'Clean Voice 或 Natural Voice' }, { label: '强度', value: '每个控制项都可以独立微调' }, { label: '结果', value: '任务完成后打开播放器或我的作品' }], route: '/enhancement', selector: '[data-guide="enhancement-controls"], [data-guide="enhancement-run"]', placement: 'left', icon: MagicStick },
+  { section: '我的作品 · 34', targetLabel: '作品筛选与列表', title: '管理所有生成任务和成品', description: '作品库按全部、已完成、生成中、排队和失败筛选，也能搜索作品名或模型名。每行都有试听、下载、增强、重试、日志和删除操作。', details: [{ label: '状态', value: '生成中和排队中的任务会自动刷新进度' }, { label: '失败', value: '打开日志查看原因并重试' }, { label: '作品', value: '重命名、下载、试听或删除成品' }], route: '/works', selector: '[data-guide="works-filter"], [data-guide="works-list"]', placement: 'bottom', icon: FolderOpened },
+  { section: '作品播放器 · 35', targetLabel: '播放器与歌词', title: '试听作品并同步歌词', description: '播放器可以导入图片或 MV 作为画面，也可以搜索或导入 LRC 歌词。点击歌词行会跳到对应时间，适合检查咬字和高音段。', details: [{ label: '画面', value: '导入、更换或移除图片 / 视频 MV' }, { label: '歌词', value: '曲库获取或导入 LRC 时间轴' }, { label: '定位', value: '点击歌词行跳转到该句' }], route: '/player', selector: '[data-guide="player-visual"], [data-guide="player-lyrics"], [data-guide="player-empty"]', placement: 'right', icon: Microphone, prepare: 'open-player' },
+  { section: '作品播放器 · 36', targetLabel: '播放进度与音量', title: '拖动进度条检查最终成品', description: '底部播放条支持播放、暂停、任意时间定位和音量调整。与翻唱工作台的输出进度条一样，定位后可以快速回到问题段落。', details: [{ label: '播放', value: '播放 / 暂停成品音频' }, { label: '进度', value: '拖动滑杆定位到任意时间' }, { label: '导出', value: '右上角下载当前作品文件' }], route: '/player', selector: '[data-guide="player-transport"], [data-guide="player-empty"]', placement: 'top', icon: MagicStick, prepare: 'open-player' },
+  { section: '我的模型 · 37', targetLabel: '模型导入与检测', title: '导入、检查和整理本地模型', description: '模型管理页按框架提供对应文件选择器。导入后可以检测元数据、修复可推断配置、收藏、设为默认或分享到模型站。', details: [{ label: '导入', value: '按框架选择权重、配置、索引和扩散文件' }, { label: '检测', value: '发现缺失元数据时可尝试修复' }, { label: '默认', value: '设为默认后新建翻唱会优先选它' }], route: '/models', selector: '[data-guide="model-list"]', placement: 'right', icon: FolderOpened },
+  { section: '我的模型 · 38', targetLabel: '模型重命名', title: '给自己的模型起一个容易记的名字', description: '点击模型行的编辑按钮即可重命名。名称只影响界面显示和作品标签，不会改动权重文件、路径或模型 ID。', details: [{ label: '建议', value: '用“角色 · 音域 · 风格”组合命名' }, { label: '同步', value: '翻唱工作台、多模型时间轴和作品库都会显示新名称' }, { label: '安全', value: '不会移动、覆盖或重写模型文件' }], route: '/models', selector: '[data-guide="model-rename"]', placement: 'top', icon: Setting },
+  { section: '插件中心 · 39', targetLabel: '插件设置与安装', title: '按需扩展工作台', description: '插件中心的总开关默认可以保持关闭。需要扩展时先配置市场地址或安装本地 .xbplugin / .zip，再单独启用可信插件。', details: [{ label: '总开关', value: '关闭时不影响原有翻唱流程' }, { label: '安装', value: '市场安装或本地插件包安装' }, { label: '权限', value: '查看插件运行环境和权限摘要后再启用' }], route: '/plugins', selector: '[data-guide="plugin-settings"]', placement: 'right', icon: FolderOpened },
+  { section: '插件中心 · 40', targetLabel: '已安装插件与市场', title: '管理插件页面和运行状态', description: '市场区域用于发现和安装扩展，已安装区域可以逐个打开、启用或卸载。前端页面插件和运行时插件都会显示自己的状态。', details: [{ label: '单独启用', value: '某个插件异常时可只关闭它' }, { label: '打开', value: '进入插件提供的工作页面' }, { label: '卸载', value: '移除插件包，不影响模型和作品' }], route: '/plugins', selector: '[data-guide="plugin-installed"], [data-guide="plugin-market"]', placement: 'bottom', icon: MagicStick },
+  { section: 'API 接入 · 41', targetLabel: '服务配置', title: '需要外部调用时再启动 API', description: 'API 服务默认停止，只在本次运行期间手动启动。可以选择仅本机或局域网、修改端口、复制 API Key 并做连通性测试。', details: [{ label: '安全', value: '优先使用仅本机监听，局域网只在可信网络开启' }, { label: '密钥', value: '调用受保护接口时放在 X-API-Key 请求头' }, { label: '生命周期', value: '停止服务后外部任务无法继续访问' }], route: '/api', selector: '[data-guide="api-service"]', placement: 'right', icon: Setting },
+  { section: 'API 接入 · 42', targetLabel: '调用文档', title: '按文档接入上传、任务和下载', description: '调用文档提供 Python 和 PowerShell 示例，以及完整的 v1 接口列表。典型流程是上传音频、读取模型、创建任务、轮询状态，最后下载成品。', details: [{ label: '示例', value: '切换语言后复制完整请求代码' }, { label: '异步任务', value: '创建返回 202，轮询到 done 再下载' }, { label: '接口', value: '健康检查、模型、上传、任务、结果和重试' }], route: '/api', selector: '[data-guide="api-docs"]', placement: 'top', icon: FolderOpened },
+]
+
+const activeStep = computed(() => steps[currentStep.value] ?? steps[0]!)
+const focusStyle = computed(() => {
+  const rect = targetRect.value
+  if (!rect) return {}
+  const pad = 8
+  return {
+    top: `${Math.max(8, rect.top - pad)}px`,
+    left: `${Math.max(8, rect.left - pad)}px`,
+    width: `${Math.max(12, rect.width + pad * 2)}px`,
+    height: `${Math.max(12, rect.height + pad * 2)}px`,
+  }
+})
+const calloutStyle = computed(() => {
+  const rect = targetRect.value
+  if (!rect) return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+  const margin = 18
+  const width = Math.min(380, Math.max(280, window.innerWidth - 32))
+  const estimatedHeight = Math.min(430, Math.max(260, window.innerHeight - 40))
+  let top = rect.bottom + margin
+  let left = rect.left
+  if (activeStep.value.placement === 'top') top = rect.top - estimatedHeight - margin
+  if (activeStep.value.placement === 'left') left = rect.left - width - margin
+  if (activeStep.value.placement === 'right') left = rect.right + margin
+  if (activeStep.value.placement === 'right' || activeStep.value.placement === 'left') top = rect.top + (rect.height - estimatedHeight) / 2
+  if (top + estimatedHeight > window.innerHeight - 16) top = window.innerHeight - estimatedHeight - 16
+  if (top < 16) top = 16
+  if (left + width > window.innerWidth - 16) left = window.innerWidth - width - 16
+  if (left < 16) left = 16
+  return { top: `${top}px`, left: `${left}px`, width: `${width}px` }
+})
+
+function wait(ms: number) { return new Promise<void>((resolve) => window.setTimeout(resolve, ms)) }
+
+function findTarget() {
+  const selectors = activeStep.value.selector.split(',').map((item) => item.trim()).filter(Boolean)
+  for (const selector of selectors) {
+    const target = document.querySelector<HTMLElement>(selector)
+    if (target) return target
+  }
+  return null
+}
+
+async function locateTarget() {
+  locating.value = true
+  hasTarget.value = false
+  targetRect.value = null
+  let target: HTMLElement | null = null
+  for (let attempt = 0; attempt < 75; attempt += 1) {
+    target = findTarget()
+    if (target) break
+    await wait(40)
+  }
+  if (target) {
+    target.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'smooth' })
+    await wait(220)
+    targetRect.value = target.getBoundingClientRect()
+    hasTarget.value = targetRect.value.width > 0 && targetRect.value.height > 0
+  }
+  locating.value = false
+}
+
+type GuideDemoKind = 'multi' | 'multi-timeline' | 'enhancement'
+let activeDemo: GuideDemoKind | null = null
+function emitDemo(kind: GuideDemoKind) {
+  window.dispatchEvent(new CustomEvent('xb-guide-demo', { detail: { action: 'prepare', kind } }))
+}
+function restoreDemo() {
+  if (!activeDemo) return
+  window.dispatchEvent(new CustomEvent('xb-guide-demo', { detail: { action: 'restore' } }))
+  activeDemo = null
+}
+
+async function prepareStep(step: GuideStep) {
+  if (step.prepare === 'multi' || step.prepare === 'multi-timeline' || step.prepare === 'enhancement') {
+    const kind: GuideDemoKind = step.prepare
+    if (activeDemo !== kind) {
+      restoreDemo()
+      emitDemo(kind)
+      activeDemo = kind
+      await wait(kind === 'multi-timeline' ? 260 : 160)
+    }
+    return
+  }
+  if (step.prepare !== 'open-player') {
+    restoreDemo()
+    return
+  }
+  if (step.prepare === 'open-player') {
+    restoreDemo()
+    if (route.path !== '/works') {
+      await router.push('/works')
+      await nextTick()
+    }
+    const play = document.querySelector<HTMLElement>('[data-guide="works-list"] .work-play:not(:disabled)')
+    if (play) {
+      play.click()
+      await wait(180)
+    }
+  }
+}
+
+async function goToStep(index: number) {
+  if (locating.value || index < 0 || index >= steps.length) return
+  currentStep.value = index
+  const targetRoute = activeStep.value.route
+  locating.value = true
+  try {
+    if (activeStep.value.prepare === 'open-player') {
+      await prepareStep(activeStep.value)
+      if (route.path !== targetRoute) await router.push(targetRoute)
+    } else {
+      if (route.path !== targetRoute) await router.push(targetRoute)
+      await nextTick()
+      await prepareStep(activeStep.value)
+    }
+    await nextTick()
+    await locateTarget()
+  } catch {
+    locating.value = false
+  }
+}
+
+function next() {
+  if (currentStep.value >= steps.length - 1) {
+    finish()
+    return
+  }
+  void goToStep(currentStep.value + 1)
+}
+
+function finish() {
+  restoreDemo()
+  visible.value = false
+  hasTarget.value = false
+  targetRect.value = null
+  try {
+    localStorage.setItem(STORAGE_KEY, '1')
+  } catch {
+    /* The guide can still be dismissed for this session when storage is blocked. */
+  }
+}
+
+function skip() { finish() }
+
+function updateFocus() {
+  if (!visible.value || !hasTarget.value) return
+  if (focusRaf) cancelAnimationFrame(focusRaf)
+  focusRaf = requestAnimationFrame(() => {
+    focusRaf = 0
+    const target = findTarget()
+    if (target) targetRect.value = target.getBoundingClientRect()
+  })
+}
+
+watch(() => route.path, () => {
+  if (visible.value && !locating.value) void locateTarget()
+})
+
+onMounted(() => {
+  window.addEventListener('resize', updateFocus, { passive: true })
+  window.addEventListener('scroll', updateFocus, { passive: true })
+  let shouldShow = false
+  try {
+    shouldShow = localStorage.getItem(STORAGE_KEY) !== '1'
+  } catch {
+    shouldShow = true
+  }
+  if (shouldShow) {
+    window.setTimeout(() => {
+      visible.value = true
+      void goToStep(0)
+    }, 240)
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateFocus)
+  window.removeEventListener('scroll', updateFocus)
+  if (focusRaf) cancelAnimationFrame(focusRaf)
+})
+</script>
+
+<style scoped>
+.interactive-guide { position: fixed; inset: 0; z-index: 3000; pointer-events: none; color: var(--xb-text); }
+.guide-focus { position: fixed; z-index: 1; border: 2px solid var(--xb-primary); border-radius: 9px; box-shadow: 0 0 0 9999px rgba(var(--xb-bg-rgb), .76), 0 0 0 5px rgba(var(--xb-primary-rgb), .14), 0 0 30px rgba(var(--xb-primary-rgb), .36); pointer-events: none; transition: top .28s ease, left .28s ease, width .28s ease, height .28s ease; }
+.guide-focus::after { content: ''; position: absolute; inset: -7px; border: 1px solid rgba(var(--xb-primary-rgb), .68); border-radius: 13px; animation: guide-focus-pulse 1.8s ease-in-out infinite; }
+.guide-callout { position: fixed; z-index: 2; max-height: min(470px, calc(100vh - 32px)); overflow-y: auto; padding: 16px; border: 1px solid rgba(var(--xb-primary-rgb), .34); border-radius: 12px; background: linear-gradient(145deg, rgba(var(--xb-primary-rgb), .11), transparent 46%), var(--xb-bg-2); box-shadow: 0 20px 50px rgba(var(--xb-bg-rgb), .58), 0 0 0 1px rgba(var(--xb-fill-rgb), .06) inset; pointer-events: auto; }
+.callout-header { display: flex; align-items: center; gap: 10px; min-height: 24px; }
+.callout-section { display: inline-flex; align-items: center; gap: 6px; color: var(--xb-primary); font-size: 11px; font-weight: 800; letter-spacing: .08em; }
+.callout-count { margin-left: auto; color: var(--xb-muted); font: 11px ui-monospace, monospace; }
+.callout-close { display: grid; place-items: center; width: 28px; height: 28px; margin-left: 2px; border: 0; border-radius: 7px; background: rgba(var(--xb-fill-rgb), .06); color: var(--xb-muted); cursor: pointer; }
+.callout-close:hover { color: var(--xb-text); background: rgba(var(--xb-primary-rgb), .14); }
+.callout-heading { display: flex; align-items: center; gap: 11px; margin-top: 15px; }
+.callout-icon { display: grid; flex: 0 0 auto; place-items: center; width: 42px; height: 42px; border: 1px solid rgba(var(--xb-primary-rgb), .32); border-radius: 10px; background: rgba(var(--xb-primary-rgb), .12); color: var(--xb-primary); font-size: 20px; }
+.callout-heading-copy { min-width: 0; }
+.callout-target { margin: 0 0 3px; overflow: hidden; color: var(--xb-muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.callout-heading h1 { margin: 0; font-size: 19px; line-height: 1.28; }
+.callout-description { margin: 14px 0 12px; color: var(--xb-muted); font-size: 13px; line-height: 1.65; }
+.callout-details { display: grid; gap: 7px; }
+.callout-detail { display: grid; grid-template-columns: 72px minmax(0, 1fr); gap: 8px; padding: 8px 9px; border-left: 2px solid rgba(var(--xb-primary-rgb), .52); background: rgba(var(--xb-fill-rgb), .045); font-size: 12px; line-height: 1.45; }
+.callout-detail strong { color: var(--xb-text); }
+.callout-detail span { color: var(--xb-muted); }
+.callout-locating { display: flex; align-items: center; gap: 7px; margin: 11px 0 0; color: var(--xb-primary); font-size: 11px; }
+.callout-locating i { width: 7px; height: 7px; border-radius: 50%; background: var(--xb-primary); box-shadow: 0 0 10px var(--xb-primary); animation: guide-dot-pulse 1s ease-in-out infinite; }
+.callout-locating.is-warning { color: var(--xb-warn); }
+.callout-locating.is-warning i { background: var(--xb-warn); box-shadow: 0 0 10px var(--xb-warn); animation: none; }
+.callout-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 16px; padding-top: 13px; border-top: 1px solid rgba(var(--xb-fill-rgb), .1); }
+.guide-skip, .guide-back, .guide-next { border: 0; font: inherit; cursor: pointer; }
+.guide-skip { padding: 6px 0; background: none; color: var(--xb-muted); font-size: 12px; }
+.guide-skip:hover { color: var(--xb-text); }
+.guide-actions { display: flex; align-items: center; gap: 8px; }
+.guide-back { padding: 8px 11px; border: 1px solid var(--xb-border); border-radius: 6px; background: transparent; color: var(--xb-text); font-size: 12px; }
+.guide-back:hover:not(:disabled) { border-color: var(--xb-primary); }
+.guide-next { display: inline-flex; align-items: center; gap: 7px; padding: 9px 13px; border-radius: 6px; background: var(--xb-primary); color: var(--xb-on-primary); font-size: 12px; font-weight: 800; box-shadow: 0 8px 18px rgba(var(--xb-primary-rgb), .22); }
+.guide-next:hover:not(:disabled) { filter: brightness(1.08); transform: translateY(-1px); }
+.guide-back:disabled, .guide-next:disabled { opacity: .5; cursor: wait; }
+.interactive-guide-enter-active, .interactive-guide-leave-active { transition: opacity .2s ease; }
+.interactive-guide-enter-active .guide-callout, .interactive-guide-leave-active .guide-callout { transition: opacity .22s ease, transform .22s ease; }
+.interactive-guide-enter-from, .interactive-guide-leave-to { opacity: 0; }
+.interactive-guide-enter-from .guide-callout, .interactive-guide-leave-to .guide-callout { opacity: 0; transform: translateY(10px) scale(.98); }
+@keyframes guide-focus-pulse { 0%, 100% { opacity: .35; transform: scale(1); } 50% { opacity: .9; transform: scale(1.015); } }
+@keyframes guide-dot-pulse { 0%, 100% { opacity: .45; } 50% { opacity: 1; } }
+@media (max-width: 700px) { .guide-callout { max-height: min(520px, calc(100vh - 24px)); } }
+@media (max-width: 520px) {
+  .guide-callout { width: calc(100vw - 24px) !important; max-height: calc(100vh - 24px); padding: 14px; }
+  .callout-heading h1 { font-size: 17px; }
+  .callout-detail { grid-template-columns: 64px minmax(0, 1fr); }
+  .callout-footer { align-items: stretch; }
+  .guide-actions { flex: 1; justify-content: flex-end; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .guide-focus { transition: none; }
+  .guide-focus::after, .callout-locating i { animation: none; }
+  .interactive-guide-enter-active, .interactive-guide-leave-active, .interactive-guide-enter-active .guide-callout, .interactive-guide-leave-active .guide-callout { transition: none; }
+  .guide-next:hover:not(:disabled) { transform: none; }
+}
+</style>

--- a/web/src/layouts/DefaultLayout.vue
+++ b/web/src/layouts/DefaultLayout.vue
@@ -2,6 +2,7 @@
   <div class="layout">
     <ThemeBackground />
     <AppHeader />
+    <FirstUseGuide />
 
     <main class="layout-main">
       <router-view v-slot="{ Component, route }">
@@ -16,6 +17,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted } from 'vue'
 import AppHeader from '@/components/layout/AppHeader.vue'
+import FirstUseGuide from '@/components/onboarding/FirstUseGuide.vue'
 import ThemeBackground from '@/components/theme/ThemeBackground.vue'
 import { useNotificationsStore } from '@/stores/notifications'
 

--- a/web/src/stores/models.ts
+++ b/web/src/stores/models.ts
@@ -21,6 +21,7 @@ export interface ModelVM {
   indexFile: string
   favorite: boolean
   health: 'ok' | 'warn' | 'error' | 'unknown'
+  metadata?: Record<string, unknown>
 }
 
 function guessFramework(type: string): string {
@@ -49,6 +50,7 @@ function toVM(m: ModelDTO): ModelVM {
     indexFile: m.index_file?.name || '—',
     favorite: !!m.favorite,
     health: m.metadata?.valid === true ? 'ok' : m.metadata?.valid === false ? 'error' : 'unknown',
+    metadata: m.metadata,
   }
 }
 
@@ -98,6 +100,12 @@ export const useModelsStore = defineStore('models', () => {
     return updated
   }
 
+  async function rename(id: string, name: string) {
+    const ok = await api.renameModel(id, name)
+    if (ok) await load()
+    return ok
+  }
+
   async function inspect(id: string, repair = false) {
     const res = await api.inspectModel(id, repair)
     if (repair && res.model) await load()
@@ -118,6 +126,7 @@ export const useModelsStore = defineStore('models', () => {
     setDefault,
     remove,
     toggleFavorite,
+    rename,
     inspect,
   }
 })

--- a/web/src/types/components.d.ts
+++ b/web/src/types/components.d.ts
@@ -38,6 +38,7 @@ declare module 'vue' {
     ElSwitch: typeof import('element-plus/es')['ElSwitch']
     ElTag: typeof import('element-plus/es')['ElTag']
     ElTooltip: typeof import('element-plus/es')['ElTooltip']
+    FirstUseGuide: typeof import('./../components/onboarding/FirstUseGuide.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     ThemeBackground: typeof import('./../components/theme/ThemeBackground.vue')['default']

--- a/web/src/utils/pendingAudio.ts
+++ b/web/src/utils/pendingAudio.ts
@@ -1,0 +1,17 @@
+export interface PendingAudio {
+  name: string
+  path: string
+  hint?: string
+}
+
+let pendingAudio: PendingAudio | null = null
+
+export function setPendingAudio(audio: PendingAudio) {
+  pendingAudio = audio
+}
+
+export function takePendingAudio(): PendingAudio | null {
+  const audio = pendingAudio
+  pendingAudio = null
+  return audio
+}

--- a/web/src/views/api/api.vue
+++ b/web/src/views/api/api.vue
@@ -32,7 +32,7 @@
       </div>
     </header>
 
-    <section class="control-band">
+    <section class="control-band" data-guide="api-service">
       <div class="section-title">
         <div>
           <h2>服务配置</h2>
@@ -124,7 +124,7 @@
       <p v-if="status.last_error && !status.running" class="last-error">{{ status.last_error }}</p>
     </section>
 
-    <section class="docs-band">
+    <section class="docs-band" data-guide="api-docs">
       <div class="section-title">
         <div>
           <h2>调用文档</h2>

--- a/web/src/views/create/create.vue
+++ b/web/src/views/create/create.vue
@@ -13,15 +13,15 @@
       <!-- 左侧：配置 -->
       <div class="config">
         <!-- 翻唱模式 -->
-        <section class="card glass mode-card">
-          <button class="mode-item" :class="{ active: mode === 'single' }" @click="mode = 'single'">
+        <section class="card glass mode-card" data-guide="cover-mode">
+          <button class="mode-item" data-guide="single-mode" :class="{ active: mode === 'single' }" @click="mode = 'single'">
             <el-icon><Microphone /></el-icon>
             <div class="mode-text">
               <div class="mode-name">单模型翻唱</div>
               <div class="mode-desc">整首歌用一个模型</div>
             </div>
           </button>
-          <button class="mode-item" :class="{ active: mode === 'multi' }" @click="mode = 'multi'">
+          <button class="mode-item" data-guide="multi-mode" :class="{ active: mode === 'multi' }" @click="mode = 'multi'">
             <el-icon><Operation /></el-icon>
             <div class="mode-text">
               <div class="mode-name">多模型混合</div>
@@ -30,7 +30,7 @@
           </button>
         </section>
 
-        <section class="card glass workflow-card">
+        <section class="card glass workflow-card" data-guide="cover-workflow">
           <div class="card-head">
             <span class="step-no">ADV</span>
             <h2>高级功能</h2>
@@ -58,15 +58,25 @@
         </section>
 
         <!-- 上传歌曲 -->
-        <section class="card glass">
+        <section class="card glass" data-guide="cover-upload">
           <div class="card-head">
             <span class="step-no">01</span>
             <h2>上传歌曲</h2>
           </div>
-          <div v-if="!song" class="dropzone" @click="onPickSong">
+          <div
+            v-if="!song"
+            class="dropzone"
+            :class="{ 'is-dragover': songDragActive }"
+            @click="onPickSong"
+            @dragenter.prevent="songDragActive = true"
+            @dragover.prevent="songDragActive = true"
+            @dragleave.prevent="songDragActive = false"
+            @drop.prevent="onSongDrop"
+          >
             <el-icon class="dz-icon"><UploadFilled /></el-icon>
-            <p class="dz-main">点击选择音频文件</p>
+            <p class="dz-main">点击选择或拖拽音频文件</p>
             <p class="dz-sub">支持 MP3 / WAV / FLAC，单文件 ≤ 50MB</p>
+            <input ref="songInput" type="file" accept="audio/*,.mp3,.wav,.flac,.m4a,.ogg,.aac" hidden @change="onSongFileChange" />
           </div>
           <div v-else class="song-file">
             <div class="song-cover"><el-icon><Headset /></el-icon></div>
@@ -101,7 +111,7 @@
         </section>
 
         <!-- 选择模型（单模型） -->
-        <section v-if="mode === 'single'" class="card glass">
+        <section v-if="mode === 'single'" class="card glass guide-model-select" data-guide="model-select">
           <div class="card-head">
             <span class="step-no">02</span>
             <h2>选择你的模型</h2>
@@ -141,11 +151,16 @@
         </section>
 
         <!-- 选择模型（多模型 + 各自参数） -->
-        <section v-else class="card glass">
+        <section v-else class="card glass guide-model-select" data-guide="model-select">
           <div class="card-head">
             <span class="step-no">02</span>
             <h2>选择参与模型</h2>
             <router-link to="/models" class="head-link">管理模型 <el-icon><Right /></el-icon></router-link>
+            <label class="manual-param-switch" data-guide="manual-switch">
+              <input v-model="manualParamsEnabled" type="checkbox" />
+              <span>全参数手动调整</span>
+              <small>{{ manualParamsEnabled ? '已启用' : '基础可调 · 高级默认' }}</small>
+            </label>
           </div>
           <p class="field-tip">勾选本次要混合的模型（可跨框架：So-VITS-SVC / RVC / SeedVC 同曲混用），每个模型可单独展开设置参数</p>
           <div v-if="availableFrameworks.length > 1" class="model-filter">
@@ -180,18 +195,26 @@
                 <el-icon v-if="isPicked(m.id)" class="model-check"><Select /></el-icon>
               </button>
 
-              <div v-if="isPicked(m.id)" class="mp-params">
+              <div v-if="isPicked(m.id)" class="mp-params" data-guide="multi-model-params">
                 <div class="mp-row">
                   <label>变调 {{ mp(m.id).pitch > 0 ? '+' + mp(m.id).pitch : mp(m.id).pitch }}</label>
                   <input type="range" min="-12" max="12" step="1" v-model.number="mp(m.id).pitch" />
                 </div>
-                <label class="mp-guard">
+                <label class="mp-guard high-pitch-toggle-field" data-guide="high-pitch-toggle">
                   <input v-model="mp(m.id).autoHighPitchGuard" type="checkbox" />
                   <span>自动高音保护</span>
-                  <small>高音区域先降调翻唱，完成后恢复原调</small>
+                  <small>确认高音失配时按轮次重试</small>
                 </label>
+                <div v-if="manualParamsEnabled && mp(m.id).autoHighPitchGuard" class="mp-row mp-threshold">
+                  <label>保护轮次 {{ mp(m.id).highPitchGuardRounds }} 轮</label>
+                  <input v-model.number="mp(m.id).highPitchGuardRounds" type="range" min="0" max="8" step="1" :disabled="!manualParamsEnabled" />
+                </div>
+                <div v-if="manualParamsEnabled" class="mp-row mp-threshold">
+                  <label>F0 过滤阈值 {{ mp(m.id).f0FilterThreshold.toFixed(2) }}</label>
+                  <input v-model.number="mp(m.id).f0FilterThreshold" type="range" min="0" max="1" step="0.01" :disabled="!manualParamsEnabled" />
+                </div>
                 <template v-if="frameworkOf(m.id) !== 'rvc'">
-                  <div class="mp-row">
+                  <div class="mp-row" data-guide="ratio-control">
                     <label v-if="frameworkOf(m.id) === 'seed-vc'">扩散步数 {{ qualitySteps(mp(m.id).diffusionRatio) }}</label>
                     <label v-else-if="frameworkOf(m.id) === 'ddsp-svc'">采样步数 {{ ddspQualitySteps(mp(m.id).diffusionRatio) }}</label>
                     <label v-else>扩散占比 {{ Math.round(mp(m.id).diffusionRatio * 100) }}%</label>
@@ -219,6 +242,10 @@
                   </div>
                 </template>
                 <div class="mp-inline">
+                  <div v-if="manualParamsEnabled && (frameworkOf(m.id) === 'so-vits-svc' || frameworkOf(m.id) === 'ddsp-svc')" class="mp-mini mp-speaker">
+                    <span>说话人</span>
+                    <input v-model="mp(m.id).speaker" type="text" placeholder="默认" />
+                  </div>
                   <div v-if="frameworkOf(m.id) !== 'seed-vc'" class="mp-mini">
                     <span>F0</span>
                     <select v-model="mp(m.id).f0Method">
@@ -244,7 +271,7 @@
         </section>
 
         <!-- 可选前期处理 -->
-        <section class="card glass preprocess-card">
+        <section class="card glass preprocess-card" data-guide="preprocess">
           <div class="card-head preprocess-card-head">
             <span class="step-no">03</span>
             <div class="preprocess-title-wrap">
@@ -270,7 +297,7 @@
               <span class="preprocess-label">分离引擎</span>
               <span class="preprocess-label-hint">选择适合当前设备的前置处理器</span>
             </div>
-            <div class="seg preprocess-engines">
+            <div class="seg preprocess-engines" data-guide="preprocess-engine">
               <button
                 class="seg-item"
                 :class="{ active: preprocessEngine === 'uvr' }"
@@ -353,10 +380,15 @@
         </section>
 
         <!-- 推理参数（单模型） -->
-        <section v-if="mode === 'single'" class="card glass">
+        <section v-if="mode === 'single'" class="card glass" data-guide="inference-params">
           <div class="card-head">
             <span class="step-no">04</span>
             <h2>推理参数</h2>
+            <label class="manual-param-switch" data-guide="manual-switch">
+              <input v-model="manualParamsEnabled" type="checkbox" />
+              <span>全参数手动调整</span>
+              <small>{{ manualParamsEnabled ? '已启用' : '基础可调 · 高级默认' }}</small>
+            </label>
           </div>
 
           <div class="fw-banner">
@@ -372,7 +404,7 @@
             <div class="field-hint">建议使用 1-30 秒干净人声；这不是模型文件，每次推理可以单独更换</div>
           </div>
 
-          <div v-if="selectedFramework !== 'rvc'" class="field">
+          <div v-if="selectedFramework !== 'rvc'" class="field" data-guide="ratio-control">
             <div class="field-row">
               <label>{{ selectedFramework === 'seed-vc' ? 'SeedVC 推理质量' : selectedFramework === 'ddsp-svc' ? 'DDSP-SVC 推理质量' : '主模型 / 扩散模型 比例' }}</label>
               <span class="field-val">
@@ -410,12 +442,36 @@
             <div class="field-hint">男声转女声建议 +12，女声转男声建议 -12</div>
           </div>
 
+          <div v-if="manualParamsEnabled && (selectedFramework === 'so-vits-svc' || selectedFramework === 'ddsp-svc')" class="field">
+            <label class="field-block-label">目标说话人 / 音色 ID</label>
+            <input v-model="speaker" class="text-input" type="text" placeholder="留空使用模型默认说话人" />
+            <div class="field-hint">不同模型的说话人命名可能不同，按模型配置填写名称或数字 ID</div>
+          </div>
+
           <div class="field">
-            <label class="field-block-label">
+            <label class="field-block-label high-pitch-toggle-field" data-guide="high-pitch-toggle">
               <input v-model="autoHighPitchGuard" type="checkbox" />
               自动高音保护
             </label>
-            <div class="field-hint">仅对超出模型音域的高音区域降调翻唱，再升回原调并补偿响度</div>
+            <div class="field-hint">检测到模型高音失配时按轮次重试</div>
+          </div>
+
+          <div v-if="manualParamsEnabled && autoHighPitchGuard" class="field">
+            <div class="field-row">
+              <label>高音保护轮次</label>
+              <span class="field-val">{{ highPitchGuardRounds }} 轮</span>
+            </div>
+            <input type="range" min="0" max="8" step="1" v-model.number="highPitchGuardRounds" />
+            <div class="field-hint">每轮失败后会根据实际哑音位置自动降低内部保护起点</div>
+          </div>
+
+          <div v-if="manualParamsEnabled" class="field">
+            <div class="field-row">
+              <label>F0 过滤阈值</label>
+              <span class="field-val">{{ f0FilterThreshold.toFixed(2) }}</span>
+            </div>
+            <input type="range" min="0" max="1" step="0.01" v-model.number="f0FilterThreshold" />
+            <div class="field-hint">过滤低置信度基频候选；数值越高越严格</div>
           </div>
 
           <div v-if="selectedFramework !== 'seed-vc'" class="field">
@@ -497,7 +553,7 @@
         </section>
 
         <!-- 歌词与分句指派（多模型） -->
-        <section v-else class="card glass">
+        <section v-else class="card glass" data-guide="multi-lyrics">
           <div class="card-head">
             <span class="step-no">04</span>
             <h2>歌词分句指派</h2>
@@ -553,7 +609,7 @@
           </div>
 
           <!-- 可视化时间轴（缩略预览，编辑在弹窗中进行，避免撑破内联布局）-->
-          <div v-if="segments.length && pickedModels.length" class="timeline-wrap">
+          <div v-if="segments.length && pickedModels.length" class="timeline-wrap" data-guide="multi-timeline">
             <div class="timeline-head">
               <span class="tl-title"><el-icon><Operation /></el-icon> 时间轴</span>
               <div class="tl-tools">
@@ -617,7 +673,7 @@
             </div>
             <!-- 横向可滚动的缩放视口：trackEl 量取的是固定宽度的外层视口，
                  与内部会随缩放变宽的 .tl-inner 彻底解耦，避免 ResizeObserver 自反馈把轨道越撑越大 -->
-            <div ref="trackEl" class="tl-viewport">
+            <div ref="trackEl" class="tl-viewport" data-guide="multi-timeline-dialog">
               <div class="tl-scroll tl-scroll-lg">
                 <div class="tl-inner" :style="{ width: innerPx + 'px' }">
                 <!-- 时间刻度 -->
@@ -771,7 +827,7 @@
           </div>
         </section>
 
-        <section class="card glass enhancement-card">
+        <section class="card glass enhancement-card" data-guide="cover-enhancement">
           <div class="card-head enhancement-head">
             <span class="step-no">05</span>
             <div class="enhancement-title">
@@ -782,12 +838,13 @@
               >{{ vocalEnhancementReady ? '引擎就绪' : '环境未安装' }}</span>
             </div>
             <el-switch
+              data-guide="enhancement-toggle"
               v-model="vocalEnhancementEnabled"
               :disabled="!vocalEnhancementReady || !enhancementWorkflowAllowed"
               aria-label="启用 AI 歌声增强"
             />
           </div>
-          <div v-if="vocalEnhancementEnabled && enhancementWorkflowAllowed" class="enhancement-levels">
+          <div v-if="vocalEnhancementEnabled && enhancementWorkflowAllowed" class="enhancement-levels" data-guide="enhancement-levels">
             <button
               type="button"
               class="enhancement-level"
@@ -815,7 +872,7 @@
               <el-icon v-if="vocalEnhancementLevel === 'advanced'" class="level-check"><Select /></el-icon>
             </button>
           </div>
-          <div v-if="vocalEnhancementEnabled && enhancementWorkflowAllowed" class="enhancement-controls">
+          <div v-if="vocalEnhancementEnabled && enhancementWorkflowAllowed" class="enhancement-controls" data-guide="enhancement-controls">
             <div class="enhancement-control">
               <div class="enhancement-control-label">
                 <span>自然修音</span>
@@ -897,7 +954,7 @@
           <p v-else-if="!enhancementWorkflowAllowed" class="enhancement-note">手动人声合并将在编辑器导出后处理</p>
         </section>
 
-        <section class="card glass infer-tools">
+        <section class="card glass infer-tools" data-guide="cover-ecosystem">
           <div class="card-head">
             <span class="step-no">ECO</span>
             <h2>推理生态</h2>
@@ -925,6 +982,7 @@
         </section>
 
         <el-button
+          data-guide="cover-generate"
           size="large"
           round
           class="cta-btn generate-btn"
@@ -938,7 +996,7 @@
 
       <!-- 右侧：预览 / 进度 -->
       <div class="preview">
-        <section class="card glass result-card">
+        <section class="card glass result-card" data-guide="cover-output">
           <div class="corner tl"></div>
           <div class="corner tr"></div>
           <div class="corner bl"></div>
@@ -968,6 +1026,10 @@
                 <el-icon class="el-icon--left"><Operation /></el-icon>进入编辑器
               </el-button>
             </div>
+            <div class="preview-seek" data-guide="preview-seek">
+              <input v-model.number="previewCurrentTime" type="range" min="0" :max="previewDuration || 0" step="0.01" :disabled="!done || !previewDuration" @input="seekPreview" />
+              <span>{{ formatPreviewTime(previewCurrentTime) }} / {{ formatPreviewTime(previewDuration) }}</span>
+            </div>
           </div>
           <audio
             ref="audioEl"
@@ -975,6 +1037,8 @@
             @play="isPlaying = true"
             @pause="isPlaying = false"
             @ended="isPlaying = false"
+            @loadedmetadata="onPreviewMetadata"
+            @timeupdate="onPreviewTimeUpdate"
           />
         </section>
 
@@ -1058,6 +1122,7 @@ import {
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
   api,
+  isDesktop,
   type WorkDTO,
   type PipelineStep,
   type DownloadedMusic,
@@ -1077,6 +1142,7 @@ import { useModelsStore } from '@/stores/models'
 import { useSystemStore } from '@/stores/system'
 import { useWorksStore } from '@/stores/works'
 import { f0MethodsForFramework, normalizeF0Method } from '@/utils/f0'
+import { takePendingAudio } from '@/utils/pendingAudio'
 
 defineOptions({ name: 'CreatePage' })
 
@@ -1108,6 +1174,8 @@ const num = (v: unknown, d: number) => (typeof v === 'number' ? v : d)
 const str = (v: unknown, d: string) => (typeof v === 'string' ? v : d)
 
 const song = ref<Song | null>(null)
+const songInput = ref<HTMLInputElement | null>(null)
+const songDragActive = ref(false)
 const selectedModel = ref<string>('')
 
 const uvrModels = ['MDX-Net', 'Demucs v4', 'VR Arch']
@@ -1155,7 +1223,11 @@ watch(harmonyModel, () => { void refreshPymssStatus() })
 const f0Method = ref(normalizeF0Method('so-vits-svc', str(prefs.f0Method, 'rmvpe')))
 
 const pitch = ref(num(prefs.pitch, 0))
+const manualParamsEnabled = ref(prefs.manualParamsEnabled === true)
+const speaker = ref(str(prefs.speaker, ''))
 const autoHighPitchGuard = ref(prefs.autoHighPitchGuard !== false)
+const highPitchGuardRounds = ref(Math.max(0, Math.min(8, Math.round(num(prefs.highPitchGuardRounds, 3)))))
+const f0FilterThreshold = ref(Math.max(0, Math.min(1, num(prefs.f0FilterThreshold, 0.05))))
 const formantShift = ref(Math.max(-2, Math.min(2, num(prefs.formantShift, 0))))
 const indexRate = ref(num(prefs.indexRate, 0.75))
 const rmsMix = ref(num(prefs.rmsMix, 0.25))
@@ -1260,6 +1332,7 @@ function normalizeDeviceSelections() {
 /* ===== 多模型混合翻唱 ===== */
 type MultiParams = {
   pitch: number
+  speaker: string
   formantShift: number
   diffusionRatio: number
   f0Method: string
@@ -1271,37 +1344,52 @@ type MultiParams = {
   rvcVersion: string
   referenceAudio: string
   autoHighPitchGuard: boolean
+  highPitchGuardRounds: number
+  f0FilterThreshold: number
 }
 
 type ParamValues = MultiParams
 
 function paramsForFramework(framework: string, values: ParamValues): InferenceParams {
+  const manual = manualParamsEnabled.value
+  const effective: ParamValues = manual
+    ? values
+    : {
+        ...values,
+        speaker: '',
+        highPitchGuardRounds: 3,
+        f0FilterThreshold: 0.05,
+      }
   const params: InferenceParams = {
-    pitch: Math.round(values.pitch),
+    pitch: Math.round(effective.pitch),
+    speaker: (effective.speaker || '').trim(),
     uvr_model: uvrModel.value,
     preprocess_enabled: preprocessEnabled.value,
     preprocess_engine: preprocessEngine.value,
     pymss_model: pymssModel.value,
-    device: values.device,
-    auto_high_pitch_guard: values.autoHighPitchGuard,
+    device: effective.device,
+    auto_high_pitch_guard: effective.autoHighPitchGuard,
+    high_pitch_guard_rounds: Math.max(0, Math.min(8, Math.round(Number(effective.highPitchGuardRounds ?? 3)))),
+    f0_filter_threshold: Math.max(0, Math.min(1, Number(effective.f0FilterThreshold ?? 0.05))),
+    manual_params_enabled: manual,
   }
   if (framework === 'seed-vc') {
-    params.diffusion_ratio = values.diffusionRatio
+    params.diffusion_ratio = effective.diffusionRatio
     params.reference_audio = values.referenceAudio
   } else if (framework === 'rvc') {
-    params.f0_method = normalizeF0Method(framework, values.f0Method)
-    params.index_rate = values.indexRate
-    params.rms_mix = values.rmsMix
-    params.protect = values.protect
-    params.filter_radius = Math.round(values.filterRadius)
-    params.rvc_version = values.rvcVersion
+    params.f0_method = normalizeF0Method(framework, effective.f0Method)
+    params.index_rate = effective.indexRate
+    params.rms_mix = effective.rmsMix
+    params.protect = effective.protect
+    params.filter_radius = Math.round(effective.filterRadius)
+    params.rvc_version = effective.rvcVersion
   } else if (framework === 'ddsp-svc') {
-    params.f0_method = normalizeF0Method(framework, values.f0Method)
-    params.ddsp_infer_steps = ddspQualitySteps(values.diffusionRatio)
-    params.ddsp_formant_shift = Number(Math.max(-2, Math.min(2, values.formantShift)).toFixed(2))
+    params.f0_method = normalizeF0Method(framework, effective.f0Method)
+    params.ddsp_infer_steps = ddspQualitySteps(effective.diffusionRatio)
+    params.ddsp_formant_shift = Number(Math.max(-2, Math.min(2, effective.formantShift)).toFixed(2))
   } else {
-    params.f0_method = normalizeF0Method(framework, values.f0Method)
-    params.diffusion_ratio = values.diffusionRatio
+    params.f0_method = normalizeF0Method(framework, effective.f0Method)
+    params.diffusion_ratio = effective.diffusionRatio
   }
   return params
 }
@@ -1385,6 +1473,7 @@ function timelineModelColor(index: number): string {
 function defaultParams(framework: string): MultiParams {
   return {
     pitch: pitch.value,
+    speaker: speaker.value,
     formantShift: formantShift.value,
     diffusionRatio: diffusionRatio.value,
     f0Method: normalizeF0Method(framework, f0Method.value),
@@ -1396,6 +1485,8 @@ function defaultParams(framework: string): MultiParams {
     rvcVersion: rvcVersion.value,
     referenceAudio: '',
     autoHighPitchGuard: autoHighPitchGuard.value,
+    highPitchGuardRounds: highPitchGuardRounds.value,
+    f0FilterThreshold: f0FilterThreshold.value,
   }
 }
 function mp(id: string): MultiParams {
@@ -1790,6 +1881,114 @@ function onTlClosed() {
   zoom.value = 1
 }
 
+/* 首次使用引导的演示状态：只在引导期间临时准备多模型时间轴 / AI 增强，离开后完整恢复。 */
+type GuideDemoKind = 'multi' | 'multi-timeline' | 'enhancement'
+interface GuideDemoSnapshot {
+  mode: 'single' | 'multi'
+  workflow: CreateWorkflow
+  manualParamsEnabled: boolean
+  selectedMulti: string[]
+  modelParams: Record<string, MultiParams>
+  lyrics: LyricLine[]
+  segments: EditSegment[]
+  lyricTried: boolean
+  audioDuration: number
+  tlDialog: boolean
+  vocalEnhancementEnabled: boolean
+}
+let guideDemoSnapshot: GuideDemoSnapshot | null = null
+const activeGuideDemoKind = ref<GuideDemoKind | null>(null)
+
+function cloneGuideValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function beginGuideDemo() {
+  if (guideDemoSnapshot) return
+  guideDemoSnapshot = {
+    mode: mode.value,
+    workflow: workflow.value,
+    manualParamsEnabled: manualParamsEnabled.value,
+    selectedMulti: [...selectedMulti.value],
+    modelParams: cloneGuideValue(modelParams),
+    lyrics: cloneGuideValue(lyrics.value),
+    segments: cloneGuideValue(segments.value),
+    lyricTried: lyricTried.value,
+    audioDuration: audioDuration.value,
+    tlDialog: tlDialog.value,
+    vocalEnhancementEnabled: vocalEnhancementEnabled.value,
+  }
+}
+
+function restoreGuideDemo() {
+  const saved = guideDemoSnapshot
+  if (!saved) return
+  mode.value = saved.mode
+  workflow.value = saved.workflow
+  manualParamsEnabled.value = saved.manualParamsEnabled
+  selectedMulti.value = [...saved.selectedMulti]
+  for (const key of Object.keys(modelParams)) delete modelParams[key]
+  Object.assign(modelParams, cloneGuideValue(saved.modelParams))
+  lyrics.value = cloneGuideValue(saved.lyrics)
+  segments.value = cloneGuideValue(saved.segments)
+  lyricTried.value = saved.lyricTried
+  audioDuration.value = saved.audioDuration
+  tlDialog.value = saved.tlDialog
+  vocalEnhancementEnabled.value = saved.vocalEnhancementEnabled
+  guideDemoSnapshot = null
+  activeGuideDemoKind.value = null
+}
+
+function prepareGuideDemo(kind: GuideDemoKind) {
+  beginGuideDemo()
+  if (kind === 'enhancement') {
+    // 强制使用可展示增强控件的普通工作流；结束时会恢复用户原选择。
+    if (!enhancementWorkflowAllowed.value) workflow.value = 'auto_mix'
+    vocalEnhancementEnabled.value = true
+    return
+  }
+
+  mode.value = 'multi'
+  manualParamsEnabled.value = true
+  if (workflow.value === 'full_manual_editor') workflow.value = 'auto_mix'
+  const ids = models.value.slice(0, 2).map((item) => item.id)
+  selectedMulti.value = ids.length ? ids : selectedMulti.value
+  for (const id of selectedMulti.value) if (!modelParams[id]) modelParams[id] = defaultParams(frameworkOf(id))
+
+  if (kind === 'multi-timeline') {
+    const modelA = selectedMulti.value[0] || ''
+    const modelB = selectedMulti.value[1] || modelA
+    lyrics.value = [
+      { time: 0.8, text: '欢迎来到多模型时间轴' },
+      { time: 4.2, text: '每一句都可以选择不同音色' },
+      { time: 8.1, text: '多选模型即可制作合唱' },
+      { time: 12.3, text: '拖动边界完成精细对齐' },
+    ]
+    lyricTried.value = true
+    audioDuration.value = 17
+    segments.value = [
+      { id: newSegId(), start: 0.8, end: 4.2, modelIds: modelA ? [modelA] : [], text: '欢迎来到多模型时间轴' },
+      { id: newSegId(), start: 4.2, end: 8.1, modelIds: modelB ? [modelB] : [], text: '每一句都可以选择不同音色' },
+      { id: newSegId(), start: 8.1, end: 12.3, modelIds: modelA && modelB ? [modelA, modelB] : (modelA ? [modelA] : []), text: '多选模型即可制作合唱' },
+      { id: newSegId(), start: 12.3, end: 16.6, modelIds: [], text: '拖动边界完成精细对齐' },
+    ]
+    tlDialog.value = true
+  }
+}
+
+function onGuideDemo(event: Event) {
+  const detail = (event as CustomEvent<{ action?: string; kind?: GuideDemoKind }>).detail || {}
+  if (detail.action === 'restore') {
+    restoreGuideDemo()
+    return
+  }
+  if (detail.action === 'prepare' && detail.kind) {
+    activeGuideDemoKind.value = detail.kind
+    prepareGuideDemo(detail.kind)
+  }
+}
+window.addEventListener('xb-guide-demo', onGuideDemo)
+
 /* ---- 时间轴总览 ---- */
 /** 拖动期间冻结的总时长：拖动时锁定，避免「拖长片段→总时长变大→整轴重新缩放→边缘跑飞」的自反馈。 */
 const frozenDur = ref(0)
@@ -2022,8 +2221,9 @@ const alignStatus = computed(() => {
 
 // 任一参数变化即写回 localStorage
 watch(
-  [uvrModel, preprocessEnabled, preprocessEngine, pymssModel, harmonyRemovalEnabled, harmonyModel, f0Method, pitch, autoHighPitchGuard, formantShift, indexRate, rmsMix, diffusionRatio, seedVcReferenceAudio, device, mode, workflow, protect, filterRadius, rvcVersion, vocalEnhancementEnabled, vocalEnhancementLevel, pitchCorrection, timingAlignment, timbreFocus, aiEq, aiCompressor, aiExciter, stereoWidth, loudnessEnvelope],
+  [uvrModel, preprocessEnabled, preprocessEngine, pymssModel, harmonyRemovalEnabled, harmonyModel, f0Method, pitch, speaker, highPitchGuardRounds, f0FilterThreshold, manualParamsEnabled, autoHighPitchGuard, formantShift, indexRate, rmsMix, diffusionRatio, seedVcReferenceAudio, device, mode, workflow, protect, filterRadius, rvcVersion, vocalEnhancementEnabled, vocalEnhancementLevel, pitchCorrection, timingAlignment, timbreFocus, aiEq, aiCompressor, aiExciter, stereoWidth, loudnessEnvelope],
   () => {
+    if (activeGuideDemoKind.value) return
     try {
       localStorage.setItem(
         PREFS_KEY,
@@ -2036,6 +2236,10 @@ watch(
           harmonyModel: harmonyModel.value,
           f0Method: f0Method.value,
           pitch: pitch.value,
+          manualParamsEnabled: manualParamsEnabled.value,
+          highPitchGuardRounds: highPitchGuardRounds.value,
+          f0FilterThreshold: f0FilterThreshold.value,
+          speaker: speaker.value,
           autoHighPitchGuard: autoHighPitchGuard.value,
           formantShift: formantShift.value,
           indexRate: indexRate.value,
@@ -2147,6 +2351,21 @@ const canGenerate = computed(() => {
 
 const audioEl = ref<HTMLAudioElement | null>(null)
 const audioLoadedFor = ref<string | null>(null)
+const previewCurrentTime = ref(0)
+const previewDuration = ref(0)
+function formatPreviewTime(value: number) {
+  const total = Math.max(0, Math.floor(Number(value) || 0))
+  return `${Math.floor(total / 60).toString().padStart(2, '0')}:${(total % 60).toString().padStart(2, '0')}`
+}
+function onPreviewMetadata() {
+  previewDuration.value = Number.isFinite(audioEl.value?.duration || 0) ? Number(audioEl.value?.duration || 0) : 0
+}
+function onPreviewTimeUpdate() {
+  previewCurrentTime.value = Number(audioEl.value?.currentTime || 0)
+}
+function seekPreview() {
+  if (audioEl.value) audioEl.value.currentTime = previewCurrentTime.value
+}
 const editorOpenedFor = ref<string | null>(null)
 
 async function onTogglePlay() {
@@ -2161,6 +2380,8 @@ async function onTogglePlay() {
     }
     el.src = data
     audioLoadedFor.value = work.id
+    previewCurrentTime.value = 0
+    previewDuration.value = 0
   }
   if (el.paused) await el.play()
   else el.pause()
@@ -2181,6 +2402,9 @@ async function openLog() {
 function currentParams() {
   return paramsForFramework(selectedFramework.value, {
     pitch: pitch.value,
+    highPitchGuardRounds: highPitchGuardRounds.value,
+    f0FilterThreshold: f0FilterThreshold.value,
+    speaker: speaker.value,
     formantShift: formantShift.value,
     f0Method: f0Method.value,
     indexRate: indexRate.value,
@@ -2231,6 +2455,9 @@ function applyParams(raw: Record<string, unknown>) {
     : num(raw.diffusion_ratio, diffusionRatio.value)
   const next = {
     pitch: num(raw.pitch, pitch.value),
+    speaker: str(raw.speaker, speaker.value),
+    highPitchGuardRounds: Math.max(0, Math.min(8, Math.round(num(raw.high_pitch_guard_rounds, highPitchGuardRounds.value)))),
+    f0FilterThreshold: Math.max(0, Math.min(1, num(raw.f0_filter_threshold, f0FilterThreshold.value))),
     autoHighPitchGuard: raw.auto_high_pitch_guard !== false,
     formantShift: Math.max(-2, Math.min(2, num(raw.ddsp_formant_shift, formantShift.value))),
     f0Method: str(raw.f0_method, f0Method.value),
@@ -2245,6 +2472,9 @@ function applyParams(raw: Record<string, unknown>) {
     referenceAudio: str(raw.reference_audio, seedVcReferenceAudio.value),
   }
   pitch.value = next.pitch
+  speaker.value = next.speaker
+  highPitchGuardRounds.value = next.highPitchGuardRounds
+  f0FilterThreshold.value = next.f0FilterThreshold
   autoHighPitchGuard.value = next.autoHighPitchGuard
   formantShift.value = next.formantShift
   f0Method.value = normalizeF0Method(selectedFramework.value, next.f0Method)
@@ -2265,6 +2495,9 @@ function applyParams(raw: Record<string, unknown>) {
   for (const id of selectedMulti.value) {
     const p = mp(id)
     p.pitch = next.pitch
+    p.speaker = next.speaker
+    p.highPitchGuardRounds = next.highPitchGuardRounds
+    p.f0FilterThreshold = next.f0FilterThreshold
     p.formantShift = next.formantShift
     p.f0Method = normalizeF0Method(frameworkOf(id), next.f0Method)
     p.indexRate = next.indexRate
@@ -2374,10 +2607,64 @@ const overallState = computed(() => {
 })
 
 async function onPickSong() {
+  // Native bridge returns an absolute path on desktop; the hidden input keeps
+  // the same workflow available when the page is opened in a normal browser.
+  if (!isDesktop()) {
+    songInput.value?.click()
+    return
+  }
   const path = await api.pickAudioFile()
   if (!path) return
   const name = path.split(/[/\\]/).pop() || path
   song.value = { name, path, hint: '本地音频已选择' }
+  void api.getAudioDuration(path).then((value) => { audioDuration.value = value })
+}
+
+function readFileDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(new Error('无法读取拖入的音频文件'))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function setSongFromFile(file: File | undefined) {
+  if (!file) return
+  if (file.size > 50 * 1024 * 1024) {
+    ElMessage.warning('音频文件不能超过 50MB')
+    return
+  }
+  const ext = file.name.split('.').pop()?.toLowerCase() || ''
+  const allowed = ['mp3', 'wav', 'flac', 'm4a', 'ogg', 'aac', 'opus', 'wma']
+  if (!allowed.includes(ext) && !file.type.startsWith('audio/')) {
+    ElMessage.warning('请选择 MP3、WAV、FLAC 等音频文件')
+    return
+  }
+  let desktopPath = String((file as File & { path?: string }).path || '').trim()
+  if (!desktopPath && isDesktop()) {
+    try {
+      desktopPath = String(await api.importAudioData(file.name, await readFileDataUrl(file)) || '').trim()
+    } catch {
+      ElMessage.error('无法导入拖入的音频文件')
+      return
+    }
+  }
+  song.value = {
+    name: file.name,
+    path: desktopPath || file.name,
+    hint: desktopPath ? '已拖入本地音频' : '已拖入文件；桌面应用会使用其本地路径',
+  }
+}
+
+function onSongFileChange(event: Event) {
+  void setSongFromFile((event.target as HTMLInputElement).files?.[0])
+  ;(event.target as HTMLInputElement).value = ''
+}
+
+function onSongDrop(event: DragEvent) {
+  songDragActive.value = false
+  void setSongFromFile(event.dataTransfer?.files?.[0])
 }
 
 async function pickSeedVcReference() {
@@ -2464,6 +2751,7 @@ const generate = async () => {
         model_id: pm.id,
         params: paramsForFramework(framework, {
           pitch: p.pitch,
+          speaker: p.speaker,
           formantShift: p.formantShift,
           f0Method: p.f0Method,
           indexRate: p.indexRate,
@@ -2475,6 +2763,8 @@ const generate = async () => {
           rvcVersion: p.rvcVersion,
           referenceAudio: framework === 'seed-vc' ? p.referenceAudio : '',
           autoHighPitchGuard: p.autoHighPitchGuard,
+          highPitchGuardRounds: p.highPitchGuardRounds,
+          f0FilterThreshold: p.f0FilterThreshold,
         }),
       }
     })
@@ -2616,6 +2906,16 @@ onMounted(async () => {
   if (selectedModel.value && selectedMulti.value.length === 0) {
     togglePick(selectedModel.value)
   }
+  const pendingAudio = takePendingAudio()
+  if (pendingAudio) {
+    song.value = {
+      name: pendingAudio.name,
+      path: pendingAudio.path,
+      hint: pendingAudio.hint || '首页拖入音频',
+    }
+    songQuery.value = pendingAudio.name.replace(/\.[^.]+$/, '')
+    void api.getAudioDuration(pendingAudio.path).then((value) => { audioDuration.value = value })
+  }
   // 加载歌词曲库选项（与「资源获取」共用妖狐 API 来源）
   try {
     const [srcList, curSource] = await Promise.all([
@@ -2651,7 +2951,14 @@ watch(
 watch(selectedFramework, (framework) => {
   f0Method.value = normalizeF0Method(framework, f0Method.value)
 })
+watch(models, (items) => {
+  if (activeGuideDemoKind.value && activeGuideDemoKind.value !== 'enhancement' && items.length) {
+    prepareGuideDemo(activeGuideDemoKind.value)
+  }
+}, { deep: true })
 onUnmounted(() => {
+  restoreGuideDemo()
+  window.removeEventListener('xb-guide-demo', onGuideDemo)
   stopPolling()
   trackRO?.disconnect()
   window.removeEventListener('pointermove', onDragMove)
@@ -2711,6 +3018,22 @@ onUnmounted(() => {
   margin-bottom: 18px;
 }
 .card-head h2 { font-size: 17px; font-weight: 700; margin: 0; }
+.manual-param-switch {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 9px;
+  border: 1px solid color-mix(in srgb, var(--xb-primary) 30%, var(--xb-border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--xb-primary) 7%, transparent);
+  color: var(--xb-text);
+  font-size: 12px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+.manual-param-switch input { accent-color: var(--xb-primary); }
+.manual-param-switch small { color: var(--xb-muted); }
 .step-no {
   font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace;
   font-size: 13px;
@@ -2785,6 +3108,7 @@ onUnmounted(() => {
   cursor: pointer;
 }
 .dropzone:hover { border-color: var(--xb-primary); background: rgba(var(--xb-primary-rgb), 0.07); }
+.dropzone.is-dragover { border-color: var(--xb-primary); background: rgba(var(--xb-primary-rgb), 0.13); box-shadow: 0 0 0 2px rgba(var(--xb-primary-rgb), .14); }
 .dz-icon { font-size: 42px; color: var(--xb-primary); margin-bottom: 10px; }
 .dz-main { font-size: 15px; font-weight: 600; margin: 0 0 6px; }
 .dz-sub { font-size: 12.5px; color: var(--xb-muted); margin: 0; }
@@ -3261,11 +3585,28 @@ onUnmounted(() => {
   align-items: center;
   flex-wrap: wrap;
   gap: 6px 8px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--xb-primary) 24%, var(--xb-border));
+  border-left: 3px solid var(--xb-primary);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--xb-primary) 6%, transparent);
   color: var(--xb-text);
   font-size: 12.5px;
 }
 .mp-guard input { accent-color: var(--xb-primary); }
 .mp-guard small { flex-basis: 100%; color: var(--xb-muted); font-size: 11.5px; }
+.high-pitch-toggle-field { cursor: pointer; }
+.field-block-label.high-pitch-toggle-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--xb-primary) 24%, var(--xb-border));
+  border-left: 3px solid var(--xb-primary);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--xb-primary) 6%, transparent);
+}
+.field-block-label.high-pitch-toggle-field input { accent-color: var(--xb-primary); }
 .mp-inline { display: flex; gap: 10px; }
 .mp-mini { flex: 1; display: flex; align-items: center; gap: 6px; }
 .mp-mini span { font-size: 12.5px; color: var(--xb-muted); }
@@ -3279,6 +3620,17 @@ onUnmounted(() => {
   outline: none;
   font-size: 13px;
 }
+.mp-mini input, .text-input {
+  min-width: 0;
+  padding: 7px 9px;
+  border: 1px solid var(--xb-border);
+  border-radius: 8px;
+  outline: none;
+  background: rgba(var(--xb-fill-rgb), 0.04);
+  color: var(--xb-text);
+}
+.mp-mini input { flex: 1; width: 90px; }
+.text-input { width: 100%; box-sizing: border-box; }
 
 /* 歌词获取 */
 .lyric-fetch { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
@@ -3956,6 +4308,9 @@ input[type='range'] {
   justify-content: center;
   gap: 14px;
 }
+.preview-seek { display: flex; align-items: center; gap: 10px; margin-top: 18px; color: var(--xb-muted); font: 11px ui-monospace, monospace; }
+.preview-seek input { flex: 1; min-width: 0; accent-color: var(--xb-primary); cursor: pointer; }
+.preview-seek span { white-space: nowrap; }
 .play-main {
   width: 48px; height: 48px;
   border-radius: 50%;
@@ -4036,6 +4391,8 @@ input[type='range'] {
   .enhancement-controls { grid-template-columns: 1fr; gap: 10px; }
 }
 @media (max-width: 560px) {
+  .card-head { flex-wrap: wrap; }
+  .manual-param-switch { width: 100%; margin-left: 0; white-space: normal; }
   .preprocess-card { padding: 18px 16px; }
   .preprocess-card-head { margin-bottom: 17px; }
   .preprocess-title-wrap h2 { font-size: 17px; }

--- a/web/src/views/create/realtime.vue
+++ b/web/src/views/create/realtime.vue
@@ -11,7 +11,7 @@
 
     <div class="layout">
       <main class="config">
-        <section class="card glass">
+        <section class="card glass" data-guide="realtime-source">
           <div class="card-head"><span class="step-no">01</span><h2>播放源</h2></div>
           <div class="source-mode" role="group" aria-label="实时音频来源">
             <button :class="{ active: inputMode === 'system' }" :disabled="sessionActive" @click="setInputMode('system')">系统音频变声器</button>
@@ -23,11 +23,21 @@
             <label class="select-field"><span>变声输出设备</span><select v-model="systemOutputId" :disabled="sessionActive"><option value="">选择扬声器或耳机</option><option v-for="device in systemOutputDevices" :key="device.id" :value="device.id">{{ device.name }}</option></select></label>
             <button class="refresh-devices" :disabled="sessionActive" @click="loadSystemDevices"><el-icon><Refresh /></el-icon>刷新设备</button>
           </div>
-          <button v-if="inputMode === 'file' && !song" class="dropzone" @click="pickSong">
+          <button
+            v-if="inputMode === 'file' && !song"
+            class="dropzone"
+            :class="{ 'is-dragover': songDragActive }"
+            @click="pickSong"
+            @dragenter.prevent="songDragActive = true"
+            @dragover.prevent="songDragActive = true"
+            @dragleave.prevent="songDragActive = false"
+            @drop.prevent="onSongDrop"
+          >
             <el-icon><UploadFilled /></el-icon>
-            <span><b>选择要实时播放的歌曲</b><small>先分离一次人声与伴奏，随后按时间顺序分块转换与播放</small></span>
+            <span><b>选择或拖拽要实时播放的歌曲</b><small>先分离一次人声与伴奏，随后按时间顺序分块转换与播放</small></span>
           </button>
-          <div v-else-if="inputMode === 'file' && song" class="song-row">
+          <input ref="songInput" type="file" accept="audio/*,.mp3,.wav,.flac,.m4a,.ogg,.aac" hidden @change="onSongFileChange" />
+          <div v-if="inputMode === 'file' && song" class="song-row">
             <span class="song-icon"><el-icon><Headset /></el-icon></span>
             <span class="song-copy"><b>{{ song.name }}</b><small>{{ song.hint }} · {{ formatTime(duration) }}</small></span>
             <button class="icon-btn" title="更换歌曲" :disabled="sessionActive" @click="pickSong"><el-icon><Refresh /></el-icon></button>
@@ -42,7 +52,7 @@
           </div>
         </section>
 
-        <section class="card glass">
+        <section class="card glass" data-guide="realtime-params">
           <div class="card-head"><span class="step-no">02</span><h2>演唱编排</h2></div>
           <p v-if="!realtimeModels.length" class="empty-note">暂无可用的 RVC / SeedVC 模型，请先在模型管理中导入。</p>
           <div v-else class="model-grid">
@@ -62,7 +72,15 @@
 
           <div v-if="selectedId" class="model-settings">
             <template v-for="id in [selectedId]" :key="id">
-            <div class="setting-title"><b>{{ modelName(id) }}</b><span>{{ frameworkName(frameworkOf(id)) }}</span></div>
+            <div class="setting-title">
+              <b>{{ modelName(id) }}</b>
+              <span>{{ frameworkName(frameworkOf(id)) }}</span>
+              <label class="manual-param-switch">
+                <input v-model="manualParamsEnabled" type="checkbox" :disabled="sessionActive" />
+                <span>全参数手动调整</span>
+                <small>{{ manualParamsEnabled ? '已启用' : '基础可调 · 高级默认' }}</small>
+              </label>
+            </div>
             <div class="param-grid">
               <label class="range-row">
                 <span>变调 <b>{{ paramsFor(id).pitch > 0 ? '+' : '' }}{{ paramsFor(id).pitch }} 半音</b></span>
@@ -89,6 +107,10 @@
                 <input v-model.number="paramsFor(id).filterRadius" type="range" min="0" max="7" step="1" :disabled="sessionActive" />
               </label>
             </div>
+            <label v-if="manualParamsEnabled" class="range-row threshold-row">
+              <span>F0 过滤阈值 <b>{{ paramsFor(id).f0FilterThreshold.toFixed(2) }}</b></span>
+              <input v-model.number="paramsFor(id).f0FilterThreshold" type="range" min="0" max="1" step="0.01" :disabled="sessionActive || !manualParamsEnabled" />
+            </label>
             <div class="select-grid">
               <label v-if="frameworkOf(id) === 'rvc'" class="select-field">
                 <span>F0 算法</span>
@@ -116,6 +138,10 @@
                 <span><b>自动高音保护</b><small>高音先保共振峰降调，翻唱后升回原调</small></span>
               </label>
             </div>
+            <label v-if="manualParamsEnabled && paramsFor(id).autoHighPitchGuard" class="range-row threshold-row">
+              <span>高音保护轮次 <b>{{ paramsFor(id).highPitchGuardRounds }} 轮</b></span>
+              <input v-model.number="paramsFor(id).highPitchGuardRounds" type="range" min="0" max="8" step="1" :disabled="sessionActive || !manualParamsEnabled" />
+            </label>
             <div v-if="frameworkOf(id) === 'seed-vc'" class="reference-row">
               <span>目标音色参考</span>
               <button :disabled="sessionActive" @click="pickReference(id)">{{ baseName(paramsFor(id).referenceAudio) || '选择音频' }}</button>
@@ -133,6 +159,14 @@
             <label v-if="inputMode === 'file'" class="control"><span>伴奏 <b>{{ signedDb(musicGain) }}</b></span><input v-model.number="musicGain" type="range" min="-12" max="6" step="0.5" :disabled="sessionActive" /></label>
             <div v-else class="direct-music"><el-icon><Connection /></el-icon><span><b>原始伴奏保持不变</b><small>从同一混合音频扣除提取的人声，再与变声人声按样本时钟混合</small></span></div>
           </div>
+          <div class="select-grid realtime-selects">
+            <label class="select-field">
+              <span>人声分离模型</span>
+                <select v-model="uvrModel" :disabled="sessionActive">
+                <option v-for="model in uvrModels" :key="model" :value="model">{{ model }}</option>
+              </select>
+            </label>
+          </div>
         </section>
 
         <button class="start-btn" :disabled="!canStart || sessionActive" @click="startSession">
@@ -141,7 +175,7 @@
       </main>
 
       <aside class="monitor">
-        <section class="card glass monitor-card">
+        <section class="card glass monitor-card" data-guide="realtime-monitor">
           <div class="monitor-head"><span class="live-dot" :class="statusClass"></span><span>{{ statusLabel }}</span><b v-if="inputMode === 'system'">系统音频</b><b v-else>{{ formatTime(playhead) }} / {{ formatTime(status.duration || duration) }}</b></div>
           <div class="visualizer" :class="{ playing }"><i v-for="n in 42" :key="n" :style="barStyle(n)"></i></div>
           <div class="progress-track"><span :style="{ width: playPercent + '%' }"></span></div>
@@ -188,6 +222,7 @@ import 'element-plus/es/components/message/style/css'
 import { ElMessage } from 'element-plus'
 import {
   api,
+  isDesktop,
   type DownloadedMusic,
   type InferenceParams,
   type RealtimeCoverStatus,
@@ -203,6 +238,8 @@ defineOptions({ name: 'RealtimeCoverPage' })
 interface Song { name: string; path: string; hint: string }
 interface LiveParams {
   pitch: number
+  highPitchGuardRounds: number
+  f0FilterThreshold: number
   diffusionRatio: number
   referenceAudio: string
   device: string
@@ -221,6 +258,8 @@ const worksStore = useWorksStore()
 const { models } = storeToRefs(modelsStore)
 const inputMode = ref<'system' | 'file'>('system')
 const song = ref<Song | null>(null)
+const songInput = ref<HTMLInputElement | null>(null)
+const songDragActive = ref(false)
 const duration = ref(0)
 const downloaded = ref<DownloadedMusic[]>([])
 const selectedId = ref('')
@@ -229,6 +268,9 @@ const systemOutputId = ref('')
 const systemInputDevices = ref<Array<{ id: string; name: string; kind: 'input' | 'output'; loopback?: boolean; system_mix?: boolean }>>([])
 const systemOutputDevices = ref<Array<{ id: string; name: string; kind: 'input' | 'output'; loopback?: boolean }>>([])
 const modelParams = reactive<Record<string, LiveParams>>({})
+const manualParamsEnabled = ref(false)
+const uvrModels = ['MDX-Net', 'Demucs v4', 'VR Arch']
+const uvrModel = ref('MDX-Net')
 const bufferSeconds = ref(8)
 const chunkSeconds = ref(8)
 const vocalGain = ref(0)
@@ -293,6 +335,8 @@ function errorMessage(error: unknown, fallback: string) {
 function paramsFor(id: string) {
   return modelParams[id] ||= {
     pitch: 0,
+    highPitchGuardRounds: 3,
+    f0FilterThreshold: 0.05,
     diffusionRatio: 0.5,
     referenceAudio: '',
     device: 'auto',
@@ -341,10 +385,57 @@ async function loadSystemDevices() {
 }
 
 async function pickSong() {
+  if (!isDesktop()) {
+    songInput.value?.click()
+    return
+  }
   const path = await api.pickAudioFile()
   if (!path) return
   song.value = { path, name: baseName(path), hint: '本地音频已选择' }
   duration.value = await api.getAudioDuration(path)
+}
+
+function readFileDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(new Error('无法读取拖入的音频文件'))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function setSongFromFile(file: File | undefined) {
+  if (!file) return
+  if (file.size > 50 * 1024 * 1024) {
+    ElMessage.warning('音频文件不能超过 50MB')
+    return
+  }
+  if (!file.type.startsWith('audio/') && !/\.(mp3|wav|flac|m4a|ogg|aac|opus|wma)$/i.test(file.name)) {
+    ElMessage.warning('请选择音频文件')
+    return
+  }
+  let path = String((file as File & { path?: string }).path || '').trim()
+  if (!path && isDesktop()) {
+    try {
+      path = String(await api.importAudioData(file.name, await readFileDataUrl(file)) || '').trim()
+    } catch {
+      ElMessage.error('无法导入拖入的音频文件')
+      return
+    }
+  }
+  if (!path) path = file.name
+  song.value = { name: file.name, path, hint: '已导入音频' }
+  void loadSongDuration()
+}
+
+function onSongFileChange(event: Event) {
+  void setSongFromFile((event.target as HTMLInputElement).files?.[0])
+  ;(event.target as HTMLInputElement).value = ''
+}
+
+function onSongDrop(event: DragEvent) {
+  songDragActive.value = false
+  void setSongFromFile(event.dataTransfer?.files?.[0])
 }
 
 function pickDownloaded(item: DownloadedMusic) {
@@ -364,26 +455,36 @@ async function pickReference(id: string) {
 
 function inferenceParams(id: string): InferenceParams {
   const values = paramsFor(id)
+  const effective = manualParamsEnabled.value
+      ? values
+    : {
+        ...values,
+        highPitchGuardRounds: 3,
+        f0FilterThreshold: 0.05,
+      }
+  const common = {
+    pitch: Math.round(effective.pitch),
+    device: effective.device,
+    uvr_model: uvrModel.value,
+    auto_high_pitch_guard: effective.autoHighPitchGuard,
+    high_pitch_guard_rounds: Math.max(0, Math.min(8, Math.round(effective.highPitchGuardRounds ?? 3))),
+    f0_filter_threshold: effective.f0FilterThreshold,
+    manual_params_enabled: manualParamsEnabled.value,
+  }
   return frameworkOf(id) === 'seed-vc'
     ? {
-        pitch: Math.round(values.pitch),
-        device: values.device,
-        diffusion_ratio: values.diffusionRatio,
+        ...common,
+        diffusion_ratio: effective.diffusionRatio,
         reference_audio: values.referenceAudio,
-        uvr_model: 'MDX-Net',
-        auto_high_pitch_guard: values.autoHighPitchGuard,
       }
     : {
-        pitch: Math.round(values.pitch),
-        device: values.device,
-        f0_method: normalizeF0Method('rvc', values.f0Method),
-        index_rate: values.indexRate,
-        rms_mix: values.rmsMix,
-        protect: values.protect,
-        filter_radius: Math.round(values.filterRadius),
-        rvc_version: values.rvcVersion,
-        uvr_model: 'MDX-Net',
-        auto_high_pitch_guard: values.autoHighPitchGuard,
+        ...common,
+        f0_method: normalizeF0Method('rvc', effective.f0Method),
+        index_rate: effective.indexRate,
+        rms_mix: effective.rmsMix,
+        protect: effective.protect,
+        filter_radius: Math.round(effective.filterRadius),
+        rvc_version: effective.rvcVersion,
       }
 }
 
@@ -561,6 +662,7 @@ h1 { margin: 0; font-size: 30px; letter-spacing: 0; } .page-sub { margin: 8px 0 
 .card-head h2 { margin: 0; font-size: 16px; letter-spacing: 0; } .card-head .text-action { margin-left: auto; color: var(--accent, #00d5ff); }
 .step-no { display: grid; place-items: center; min-width: 28px; height: 24px; padding: 0 6px; border: 1px solid color-mix(in srgb, var(--accent, #00d5ff) 45%, transparent); color: var(--accent, #00d5ff); font-size: 11px; }
 .dropzone { width: 100%; min-height: 112px; display: flex; justify-content: center; align-items: center; gap: 14px; border: 1px dashed var(--border-color, #344151); background: color-mix(in srgb, var(--accent, #00d5ff) 4%, transparent); color: inherit; cursor: pointer; }
+.dropzone.is-dragover { border-color: var(--accent, #00d5ff); background: color-mix(in srgb, var(--accent, #00d5ff) 14%, transparent); }
 .dropzone > .el-icon { font-size: 30px; color: var(--accent, #00d5ff); } .dropzone span { display: grid; text-align: left; gap: 5px; } small { color: var(--text-muted, #8f9aaa); font-size: 12px; }
 .song-row { display: flex; align-items: center; gap: 12px; min-height: 64px; padding: 10px; border: 1px solid var(--border-color, #344151); }
 .song-icon, .model-mark { display: grid; place-items: center; width: 42px; height: 42px; color: var(--accent, #00d5ff); background: color-mix(in srgb, var(--accent, #00d5ff) 12%, transparent); }
@@ -590,18 +692,22 @@ h1 { margin: 0; font-size: 30px; letter-spacing: 0; } .page-sub { margin: 8px 0 
 .check { color: var(--accent, #00d5ff); } .empty-note, .section-note { margin: 0; color: var(--text-muted, #8f9aaa); font-size: 13px; }
 .model-settings { display: grid; gap: 10px; margin-top: 12px; padding: 12px; border-left: 2px solid var(--accent, #00d5ff); background: color-mix(in srgb, var(--xb-panel, #172033) 88%, transparent); }
 .pitch-guard-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border-color); }
-.toggle-field { min-height: 42px; display: flex; align-items: center; gap: 9px; padding: 8px 10px; border: 1px solid var(--border-color); background: color-mix(in srgb, var(--xb-panel) 72%, transparent); cursor: pointer; }
+.toggle-field { min-height: 42px; display: flex; align-items: center; gap: 9px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border-color)); border-left: 3px solid var(--accent); border-radius: 7px; background: color-mix(in srgb, var(--accent) 6%, transparent); cursor: pointer; }
 .toggle-field input { width: 16px; height: 16px; accent-color: var(--accent); }
 .toggle-field span { display: grid; gap: 2px; }
 .toggle-field small { font-size: 11px; }
 .compact-range { padding: 8px 10px; border: 1px solid var(--border-color); background: color-mix(in srgb, var(--xb-panel) 72%, transparent); }
 .setting-title, .range-row > span, .reference-row { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
 .setting-title span { color: var(--text-muted, #8f9aaa); font-size: 11px; } .range-row { display: grid; gap: 7px; font-size: 13px; }
+.manual-param-switch { margin-left: auto; display: inline-flex; align-items: center; gap: 7px; padding: 6px 9px; border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border-color)); border-radius: 8px; background: color-mix(in srgb, var(--accent) 7%, transparent); color: var(--text-primary); font-size: 12px; font-weight: 650; white-space: nowrap; }
+.manual-param-switch input { accent-color: var(--accent); }
+.manual-param-switch small { color: var(--text-muted); }
 .param-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 13px 22px; }
 .direct-music { display: flex; align-items: center; gap: 9px; min-height: 42px; color: var(--accent); }
 .direct-music span { display: grid; gap: 3px; }
 .direct-music small { color: var(--text-muted); }
 .select-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.realtime-selects { margin-top: 12px; }
 .select-field { min-width: 0; display: grid; gap: 6px; color: var(--text-muted, #8f9aaa); font-size: 12px; }
 .select-field select { width: 100%; height: 34px; padding: 0 9px; border: 1px solid var(--xb-border, var(--border-color, #344151)); border-radius: 4px; background: var(--xb-panel, color-mix(in srgb, var(--app-bg, #0c1118) 92%, #fff)); color: var(--xb-text, var(--text-primary, #f4f7fb)); }
 .select-field select option { background: var(--xb-panel, #171c25); color: var(--xb-text, #f4f7fb); }
@@ -726,5 +832,5 @@ input[type='range'] { width: 100%; accent-color: var(--accent, #00d5ff); } .refe
 .sync-panel b { color: var(--xb-text, var(--text-primary, #f4f7fb)); font-size: 12px; }
 .sync-panel small { color: var(--xb-muted, var(--text-muted, #8f9aaa)); line-height: 1.45; }
 @media (max-width: 940px) { .layout { grid-template-columns: 1fr; } .monitor { position: static; } }
-@media (max-width: 640px) { .page { margin: 10px 8px 24px; padding: 20px 14px 40px; } .page-head { align-items: flex-start; flex-direction: column; } .model-grid, .control-grid, .param-grid, .select-grid, .pitch-guard-grid, .source-library-list, .system-audio-setup { grid-template-columns: 1fr; } .system-audio-note { grid-column: auto; } }
+@media (max-width: 640px) { .page { margin: 10px 8px 24px; padding: 20px 14px 40px; } .page-head { align-items: flex-start; flex-direction: column; } .model-grid, .control-grid, .param-grid, .select-grid, .pitch-guard-grid, .source-library-list, .system-audio-setup { grid-template-columns: 1fr; } .system-audio-note { grid-column: auto; } .setting-title { flex-wrap: wrap; } .manual-param-switch { width: 100%; margin-left: 0; white-space: normal; } }
 </style>

--- a/web/src/views/editor/editor.vue
+++ b/web/src/views/editor/editor.vue
@@ -40,7 +40,7 @@
       @set-params="activePluginEffect && setPluginParamJson(activePluginEffect, $event)"
     />
 
-    <div class="editor-head">
+    <div class="editor-head" data-guide="editor-toolbar">
       <div>
         <p class="eyebrow">// Audio Editor Lite</p>
         <h1>音频编辑工作台</h1>
@@ -90,7 +90,7 @@
     </div>
 
     <div v-if="project" class="editor-shell">
-      <aside class="inspector glass">
+      <aside class="inspector glass" data-guide="editor-inspector">
         <div class="project-block">
           <label>工程</label>
           <input v-model="project.title" class="title-input" @change="saveProject" />
@@ -101,7 +101,7 @@
           </div>
         </div>
 
-        <div class="tool-block">
+        <div class="tool-block" data-guide="editor-tools">
           <div class="tool-row">
             <span>吸附</span>
             <el-switch v-model="snapEnabled" />
@@ -138,7 +138,7 @@
           </el-button>
         </div>
 
-        <div class="role-block">
+        <div class="role-block" data-guide="editor-roles">
           <EditorRoleManager
             :roles="projectRoles"
             :models="models"
@@ -151,7 +151,7 @@
           />
         </div>
 
-        <div class="template-block">
+        <div class="template-block" data-guide="editor-templates">
           <TimelineTemplatePanel
             :templates="timelineTemplates"
             :active-template-id="activeTemplateId"
@@ -160,7 +160,7 @@
           />
         </div>
 
-        <div v-if="selectedClip && selectedTrack" class="clip-block">
+        <div v-if="selectedClip && selectedTrack" class="clip-block" data-guide="editor-clip">
           <div class="clip-title">
             <span>{{ selectedClip.name || '片段' }}</span>
             <button :class="{ active: selectedClip.locked }" title="锁定片段" @click="toggleClipLock">
@@ -295,7 +295,7 @@
           </div>
           </div>
 
-          <div v-if="activeInspectorPanel === 'effects'" class="effects-box">
+          <div v-if="activeInspectorPanel === 'effects'" class="effects-box" data-guide="editor-effects">
             <div class="effects-section-head">
               <label>音量包络</label>
               <el-switch
@@ -437,7 +437,7 @@
             </div>
           </div>
 
-          <div v-if="activeInspectorPanel === 'vocal'" class="stem-box">
+          <div v-if="activeInspectorPanel === 'vocal'" class="stem-box" data-guide="editor-vocal">
             <div class="stem-head">
               <label>人声编辑</label>
               <span class="stem-engine-badge">{{ separationEngine === 'pymss' ? 'PyMSS' : 'UVR' }}</span>
@@ -584,7 +584,7 @@
             </div>
           </div>
 
-          <div v-if="activeInspectorPanel === 'enhance'" class="rerun-box editor-enhance-box">
+          <div v-if="activeInspectorPanel === 'enhance'" class="rerun-box editor-enhance-box" data-guide="editor-ai-enhance">
             <label>当前片段 AI 增强</label>
             <button type="button" class="rerun-path-picker" @click="pickEditorEnhanceReference">
               {{ baseName(editorEnhanceReference) || '选择对应的原始歌曲' }}
@@ -606,7 +606,7 @@
             </el-button>
           </div>
 
-          <div v-if="activeInspectorPanel === 'rerun'" class="rerun-box">
+          <div v-if="activeInspectorPanel === 'rerun'" class="rerun-box" data-guide="editor-rerun">
             <label>局部重推理</label>
             <select v-model="rerunModelId">
               <option value="">选择模型</option>
@@ -616,6 +616,11 @@
             </select>
             <div v-if="rerunModelId" class="rerun-param-head">
               <span>{{ rerunFrameworkText }}</span>
+              <label class="editor-manual-switch">
+                <input v-model="rerunManualParamsEnabled" type="checkbox" />
+                <span>全参数手动调整</span>
+                <small>{{ rerunManualParamsEnabled ? '已启用' : '高级使用默认' }}</small>
+              </label>
               <button type="button" title="恢复默认参数" @click="resetRerunParams">
                 <el-icon><RefreshLeft /></el-icon>
               </button>
@@ -682,6 +687,12 @@
                   <input v-model.number="rerunFilterRadius" type="range" min="0" max="7" step="1" />
                 </div>
               </template>
+              <div v-if="rerunManualParamsEnabled && (isSovitsRerunModel || isDdspRerunModel)" class="rerun-param">
+                <div class="rerun-param-label">
+                  <span>目标说话人 / 音色 ID</span>
+                </div>
+                <input v-model="rerunSpeaker" type="text" placeholder="留空使用模型默认说话人" />
+              </div>
               <div class="rerun-mini-grid">
                 <div v-if="!isSeedVcRerunModel" class="rerun-mini">
                   <span>F0</span>
@@ -707,6 +718,20 @@
                 <span>高音保护</span>
                 <small>选择性降调/复原，减少高音失真</small>
               </label>
+              <div v-if="rerunManualParamsEnabled && rerunHighPitchGuard" class="rerun-param advanced-rerun-param">
+                <div class="rerun-param-label">
+                  <span>高音保护轮次</span>
+                  <b>{{ rerunHighPitchGuardRounds }} 轮</b>
+                </div>
+                <input v-model.number="rerunHighPitchGuardRounds" type="range" min="0" max="8" step="1" />
+              </div>
+              <div v-if="rerunManualParamsEnabled" class="rerun-param advanced-rerun-param">
+                <div class="rerun-param-label">
+                  <span>F0 过滤阈值</span>
+                  <b>{{ rerunF0FilterThreshold.toFixed(2) }}</b>
+                </div>
+                <input v-model.number="rerunF0FilterThreshold" type="range" min="0" max="1" step="0.01" />
+              </div>
               <label class="rerun-enhance-toggle">
                 <input v-model="rerunEnhanceEnabled" type="checkbox" />
                 <span>重推理后自动美声</span>
@@ -807,7 +832,7 @@
         </div>
       </aside>
 
-      <section class="timeline glass">
+      <section class="timeline glass" data-guide="editor-timeline">
         <div class="timeline-top">
           <div class="timeline-main-tools">
             <div class="transport">
@@ -880,7 +905,7 @@
             <i class="playhead" :style="{ left: playhead * zoom + 'px' }"></i>
           </div>
 
-          <div class="tracks" :style="{ width: timelineWidth + 'px' }">
+          <div class="tracks" data-guide="editor-tracks" :style="{ width: timelineWidth + 'px' }">
             <div v-for="track in project.tracks" :key="track.id" class="track-row">
               <div class="track-label" @pointerdown.stop>
                 <button :title="track.locked ? '解除轨道锁定' : '锁定轨道'" :class="{ active: track.locked }" @click="toggleTrackLock(track)">
@@ -1037,6 +1062,7 @@ interface DragState {
   originalTrackIndex: number
 }
 interface RerunPrefs {
+  manualParamsEnabled?: boolean
   pitch?: number
   formantShift?: number
   f0Method?: string
@@ -1048,6 +1074,9 @@ interface RerunPrefs {
   filterRadius?: number
   rvcVersion?: string
   referenceAudio?: string
+  speaker?: string
+  highPitchGuardRounds?: number
+  f0FilterThreshold?: number
   enhanceEnabled?: boolean
   enhanceLevel?: 'basic' | 'advanced'
   pitchCorrection?: number
@@ -1407,6 +1436,10 @@ const rerunProtect = ref(prefNum(rerunPrefs.protect, 0.33, 0, 0.5))
 const rerunFilterRadius = ref(prefNum(rerunPrefs.filterRadius, 3, 0, 7))
 const rerunRvcVersion = ref(prefStr(rerunPrefs.rvcVersion, 'v2', rvcVersions))
 const rerunReferenceAudio = ref(prefStr(rerunPrefs.referenceAudio, ''))
+const rerunManualParamsEnabled = ref(rerunPrefs.manualParamsEnabled === true)
+const rerunSpeaker = ref(prefStr(rerunPrefs.speaker, ''))
+const rerunHighPitchGuardRounds = ref(prefNum(rerunPrefs.highPitchGuardRounds, 3, 0, 8))
+const rerunF0FilterThreshold = ref(prefNum(rerunPrefs.f0FilterThreshold, 0.05, 0, 1))
 const rerunHighPitchGuard = ref(rerunPrefs.autoHighPitchGuard !== false)
 const editorEnhanceReference = ref('')
 const rerunEnhanceEnabled = ref(Boolean(rerunPrefs.enhanceEnabled))
@@ -1491,6 +1524,7 @@ const selectedRerunFramework = computed(() => selectedRerunModel.value?.framewor
 const isRvcRerunModel = computed(() => selectedRerunFramework.value === 'rvc')
 const isSeedVcRerunModel = computed(() => selectedRerunFramework.value === 'seed-vc')
 const isDdspRerunModel = computed(() => selectedRerunFramework.value === 'ddsp-svc')
+const isSovitsRerunModel = computed(() => selectedRerunFramework.value === 'so-vits-svc')
 const canRerunSelectedClip = computed(() => {
   return (
     selectedClipEditable.value &&
@@ -1561,10 +1595,15 @@ function baseName(p: string): string {
 
 function currentRerunParams(): InferenceParams {
   const f0Method = normalizeF0Method(selectedRerunFramework.value, rerunF0Method.value)
+  const manual = rerunManualParamsEnabled.value
   const params: InferenceParams = {
     pitch: Math.round(rerunPitch.value),
     device: rerunDevice.value,
     auto_high_pitch_guard: rerunHighPitchGuard.value,
+    manual_params_enabled: manual,
+    speaker: manual ? rerunSpeaker.value.trim() : '',
+    high_pitch_guard_rounds: manual && rerunHighPitchGuard.value ? Math.round(rerunHighPitchGuardRounds.value) : 3,
+    f0_filter_threshold: manual ? rerunF0FilterThreshold.value : 0.05,
   }
   if (isSeedVcRerunModel.value) {
     params.diffusion_ratio = Number(rerunDiffusionRatio.value.toFixed(3))
@@ -1599,6 +1638,9 @@ function resetRerunParams() {
   rerunFilterRadius.value = 3
   rerunRvcVersion.value = 'v2'
   rerunReferenceAudio.value = ''
+  rerunSpeaker.value = ''
+  rerunHighPitchGuardRounds.value = 3
+  rerunF0FilterThreshold.value = 0.05
   rerunHighPitchGuard.value = true
   rerunPitchCorrection.value = 0.45
   rerunTimingAlignment.value = 0.45
@@ -3895,6 +3937,10 @@ watch(
     rerunFilterRadius,
     rerunRvcVersion,
     rerunReferenceAudio,
+    rerunManualParamsEnabled,
+    rerunSpeaker,
+    rerunHighPitchGuardRounds,
+    rerunF0FilterThreshold,
     rerunHighPitchGuard,
     rerunEnhanceEnabled,
     rerunEnhanceLevel,
@@ -3923,6 +3969,10 @@ watch(
           filterRadius: rerunFilterRadius.value,
           rvcVersion: rerunRvcVersion.value,
           referenceAudio: rerunReferenceAudio.value,
+          manualParamsEnabled: rerunManualParamsEnabled.value,
+          speaker: rerunSpeaker.value,
+          highPitchGuardRounds: rerunHighPitchGuardRounds.value,
+          f0FilterThreshold: rerunF0FilterThreshold.value,
           autoHighPitchGuard: rerunHighPitchGuard.value,
           enhanceEnabled: rerunEnhanceEnabled.value,
           enhanceLevel: rerunEnhanceLevel.value,
@@ -4679,6 +4729,22 @@ onUnmounted(() => {
   font-size: 12px;
   font-weight: 800;
 }
+.editor-manual-switch {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--xb-primary) 30%, var(--xb-border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--xb-primary) 7%, transparent);
+  color: var(--xb-text);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.editor-manual-switch input { accent-color: var(--xb-primary); }
+.editor-manual-switch small { color: var(--xb-muted); font-weight: 500; }
 .rerun-param-head button {
   width: 28px;
   height: 28px;
@@ -4705,6 +4771,13 @@ onUnmounted(() => {
 .rerun-param {
   display: grid;
   gap: 6px;
+}
+.advanced-rerun-param {
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--xb-primary) 28%, var(--xb-border));
+  border-left: 3px solid var(--xb-primary);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--xb-primary) 6%, transparent);
 }
 .rerun-param-label {
   display: flex;
@@ -4761,6 +4834,11 @@ onUnmounted(() => {
   align-items: center;
   gap: 8px;
   margin-top: 12px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--xb-primary) 22%, var(--xb-border));
+  border-left: 3px solid var(--xb-primary);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--xb-primary) 5%, transparent);
   cursor: pointer;
   font-size: 13px;
   color: var(--xb-text);
@@ -5176,5 +5254,7 @@ onUnmounted(() => {
   .inspector {
     min-height: 0;
   }
+  .rerun-param-head { flex-wrap: wrap; }
+  .editor-manual-switch { width: 100%; margin-left: 0; justify-content: space-between; white-space: normal; }
 }
 </style>

--- a/web/src/views/editor/projects.vue
+++ b/web/src/views/editor/projects.vue
@@ -10,7 +10,7 @@
         <el-button round class="ghost-btn" :loading="loading" @click="loadProjects">
           <el-icon class="el-icon--left"><Refresh /></el-icon>刷新
         </el-button>
-        <el-button round class="cta-btn" @click="importAudio">
+        <el-button round class="cta-btn" data-guide="editor-import" @click="importAudio">
           <el-icon class="el-icon--left"><FolderAdd /></el-icon>导入音频
         </el-button>
       </div>
@@ -21,7 +21,7 @@
       <p>正在加载工程</p>
     </section>
 
-    <section v-else-if="projects.length" class="project-grid">
+    <section v-else-if="projects.length" class="project-grid" data-guide="editor-project-list">
       <article v-for="item in projects" :key="item.id" class="project-card glass">
         <button class="project-main" @click="openProject(item.id)">
           <span class="project-mark"><el-icon><Scissor /></el-icon></span>
@@ -51,7 +51,7 @@
       </article>
     </section>
 
-    <section v-else class="empty-panel glass">
+    <section v-else class="empty-panel glass" data-guide="editor-project-empty">
       <el-icon><Headset /></el-icon>
       <p>暂无编辑工程</p>
       <el-button round class="cta-btn" @click="importAudio">

--- a/web/src/views/enhancement/enhancement.vue
+++ b/web/src/views/enhancement/enhancement.vue
@@ -13,7 +13,7 @@
 
     <div class="workspace">
       <div class="configuration">
-        <section class="panel glass">
+        <section class="panel glass" data-guide="enhancement-target">
           <div class="panel-head">
             <span class="step-no">01</span>
             <div>
@@ -62,7 +62,7 @@
           </button>
         </section>
 
-        <section class="panel glass">
+        <section class="panel glass" data-guide="enhancement-original">
           <div class="panel-head">
             <span class="step-no">02</span>
             <div>
@@ -110,7 +110,7 @@
           </div>
         </section>
 
-        <section class="panel glass">
+        <section class="panel glass" data-guide="enhancement-controls">
           <div class="panel-head">
             <span class="step-no">03</span>
             <div>
@@ -139,7 +139,7 @@
         </section>
       </div>
 
-      <aside class="monitor glass">
+      <aside class="monitor glass" data-guide="enhancement-run">
         <div class="monitor-head">
           <span class="monitor-icon"><el-icon><MagicStick /></el-icon></span>
           <div><p>AI ENHANCEMENT</p><h2>增强任务</h2></div>

--- a/web/src/views/index/index.vue
+++ b/web/src/views/index/index.vue
@@ -26,7 +26,16 @@
         </div>
       </div>
 
-      <div class="dropzone" @click="router.push('/create')">
+      <div
+        class="dropzone"
+        data-guide="home-dropzone"
+        :class="{ 'is-dragover': homeDropActive }"
+        @click="router.push('/create')"
+        @dragenter.prevent="homeDropActive = true"
+        @dragover.prevent="homeDropActive = true"
+        @dragleave.prevent="homeDropActive = false"
+        @drop.prevent="onHomeDrop"
+      >
         <el-icon class="dz-icon"><UploadFilled /></el-icon>
         <p class="dz-main">拖拽音频到此处</p>
         <p class="dz-sub">支持 MP3 / WAV / FLAC，单文件 ≤ 50MB</p>
@@ -92,7 +101,7 @@
         <h2>快捷功能</h2>
       </div>
       <div class="quick-grid">
-        <div class="quick-card glass" v-for="q in quickActions" :key="q.title" @click="q.action">
+        <div class="quick-card glass" v-for="q in quickActions" :key="q.title" :data-guide="q.title === 'AI 翻唱' ? 'home-ai-cover' : undefined" @click="q.action">
           <div class="quick-icon" :style="{ '--ic': q.color }">
             <el-icon><component :is="q.icon" /></el-icon>
           </div>
@@ -264,8 +273,9 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { useSystemStore } from '@/stores/system'
 import { useModelsStore } from '@/stores/models'
 import { useWorksStore } from '@/stores/works'
-import { api } from '@/api'
+import { api, isDesktop } from '@/api'
 import type { DataMigrationProgress, DataStorageStatus, JobStatus } from '@/api'
+import { setPendingAudio } from '@/utils/pendingAudio'
 
 defineOptions({ name: 'Index' })
 
@@ -279,6 +289,7 @@ const { models } = storeToRefs(modelsStore)
 const { works } = storeToRefs(worksStore)
 
 const importing = ref(false)
+const homeDropActive = ref(false)
 const migratingData = ref(false)
 const changingDataDir = ref(false)
 const dataStorage = ref<DataStorageStatus | null>(null)
@@ -370,6 +381,44 @@ const onRename = async (id: string, current: string) => {
 function onImport() {
   // 导入需手动选择多个文件，统一在「我的模型」页操作
   router.push('/models')
+}
+
+function readDropAudio(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result || ''))
+    reader.onerror = () => reject(new Error('无法读取拖入的音频文件'))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function onHomeDrop(event: DragEvent) {
+  homeDropActive.value = false
+  const file = event.dataTransfer?.files?.[0]
+  if (!file) return
+  if (file.size > 50 * 1024 * 1024) {
+    ElMessage.warning('音频文件不能超过 50MB')
+    return
+  }
+  if (!file.type.startsWith('audio/') && !/\.(mp3|wav|flac|m4a|ogg|aac|opus|wma)$/i.test(file.name)) {
+    ElMessage.warning('请选择音频文件')
+    return
+  }
+  let path = String((file as File & { path?: string }).path || '').trim()
+  if (!path || !isDesktop()) {
+    try {
+      path = String(await api.importAudioData(file.name, await readDropAudio(file)) || '').trim()
+    } catch {
+      ElMessage.error('无法导入拖入的音频文件')
+      return
+    }
+  }
+  if (!path) {
+    ElMessage.error('无法识别拖入的音频文件')
+    return
+  }
+  setPendingAudio({ name: file.name, path, hint: '首页拖入音频' })
+  await router.push('/create')
 }
 
 async function loadDataStorage() {
@@ -659,6 +708,11 @@ onUnmounted(() => {
 .dropzone:hover {
   border-color: var(--xb-primary);
   background: rgba(var(--xb-primary-rgb), 0.07);
+}
+.dropzone.is-dragover {
+  border-color: var(--xb-primary);
+  background: rgba(var(--xb-primary-rgb), 0.12);
+  box-shadow: 0 0 0 3px rgba(var(--xb-primary-rgb), 0.12);
 }
 .dz-icon {
   font-size: 46px;

--- a/web/src/views/models/models.vue
+++ b/web/src/views/models/models.vue
@@ -227,7 +227,7 @@
             </button>
           </div>
         </div>
-        <div v-if="filteredLocalModels.length" class="list glass">
+        <div v-if="filteredLocalModels.length" class="list glass" data-guide="model-list">
           <div class="row" v-for="m in filteredLocalModels" :key="m.id">
             <div class="row-cover" :style="{ background: m.color }"><el-icon><Microphone /></el-icon></div>
             <div class="row-main">
@@ -251,6 +251,9 @@
               </button>
               <button class="op" title="检测并修复元数据" @click="inspectModel(m, true)">
                 <el-icon><WarningFilled /></el-icon>
+              </button>
+              <button class="op" data-guide="model-rename" title="重命名模型" @click="renameModel(m)">
+                <el-icon><EditPen /></el-icon>
               </button>
               <el-button
                 v-if="m.id !== modelsStore.defaultId"
@@ -647,7 +650,7 @@ import { useRoute } from 'vue-router'
 import {
   Setting, FolderOpened, Connection, Document, Plus, Microphone, Star, Delete,
   Upload, Search, Close, Download, Key, Link, InfoFilled, CircleCheck, WarningFilled,
-  Loading, Headset, Picture, RefreshRight, Operation,
+  Loading, Headset, Picture, RefreshRight, Operation, EditPen,
 } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { api, type HubModelItem, type HubModelUpdateItem, type ModelFramework, type PymssDownloadJob, type PymssModel, type PymssStatus } from '@/api'
@@ -820,6 +823,26 @@ async function inspectModel(m: ModelVM, repair: boolean) {
     ElMessage.success(repair ? '模型元数据已检测并修复' : '模型检测通过')
   } else {
     ElMessage.warning((res.issues || []).map((i) => i.message).join('；') || '模型需要修复')
+  }
+}
+
+async function renameModel(m: ModelVM) {
+  try {
+    const { value } = await ElMessageBox.prompt('输入新的模型显示名称', '重命名模型', {
+      inputValue: m.name,
+      confirmButtonText: '保存',
+      cancelButtonText: '取消',
+      inputValidator: (value: string) => {
+        const normalized = value.trim().replace(/\s+/g, ' ')
+        return normalized && normalized.length <= 120 ? true : '名称不能为空且不能超过 120 个字符'
+      },
+    })
+    const normalized = value.trim().replace(/\s+/g, ' ')
+    if (normalized === m.name) return
+    if (await modelsStore.rename(m.id, normalized)) ElMessage.success('模型名称已更新')
+    else ElMessage.error('重命名失败')
+  } catch {
+    /* cancelled */
   }
 }
 
@@ -1594,6 +1617,9 @@ onUnmounted(() => {
   .update-banner { align-items: flex-start; flex-direction: column; }
   .asset-pickers, .detail-hero, .detail-grid { grid-template-columns: 1fr; }
   .row-ops .el-button span { display: none; }
+  .row { align-items: flex-start; flex-wrap: wrap; }
+  .row-main { flex-basis: calc(100% - 68px); }
+  .row-ops { width: 100%; justify-content: flex-end; }
 }
 @media (min-width: 721px) and (max-width: 1080px) {
   .framework-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/web/src/views/music/music.vue
+++ b/web/src/views/music/music.vue
@@ -25,7 +25,7 @@
     </div>
 
     <!-- 搜索栏 -->
-    <div class="toolbar glass">
+    <div class="toolbar glass" data-guide="music-search">
       <div class="source-field">
         <el-select v-model="source" class="source-select" @change="onSourceChange">
           <el-option v-for="s in sources" :key="s.id" :label="s.name" :value="s.id" />
@@ -54,7 +54,7 @@
         <h2>搜索结果</h2>
         <span class="muted">{{ resultSourceName }} ·「{{ resultKeyword }}」· {{ results.length }} 首</span>
       </div>
-      <div class="list glass">
+      <div class="list glass" data-guide="music-results">
         <div class="row" v-for="r in results" :key="r.n">
           <span class="row-no">{{ r.n }}</span>
           <button
@@ -114,7 +114,7 @@
         <h2>已下载素材</h2>
         <span class="muted">{{ downloaded.length }} 首 · 可在翻唱页选用</span>
       </div>
-      <div v-if="downloaded.length" class="list glass">
+      <div v-if="downloaded.length" class="list glass" data-guide="music-downloads">
         <div class="row" v-for="d in downloaded" :key="d.path">
           <div class="row-cover"><el-icon><Headset /></el-icon></div>
           <div class="row-main">

--- a/web/src/views/player/player.vue
+++ b/web/src/views/player/player.vue
@@ -23,7 +23,7 @@
       </header>
 
       <main class="player-layout">
-        <section class="visual-stage" :class="{ 'has-media': !!mediaData, 'has-video': hasVideo }" :style="stageStyle">
+        <section class="visual-stage" data-guide="player-visual" :class="{ 'has-media': !!mediaData, 'has-video': hasVideo }" :style="stageStyle">
           <div v-if="mediaData" class="stage-media" :class="`is-${mediaKind}`" aria-hidden="true">
             <video
               v-if="mediaKind === 'video'"
@@ -60,7 +60,7 @@
           </div>
         </section>
 
-        <section class="lyrics-panel">
+        <section class="lyrics-panel" data-guide="player-lyrics">
           <div class="panel-head">
             <div>
               <p class="eyebrow">LYRICS</p>
@@ -135,7 +135,7 @@
         </section>
       </main>
 
-      <section class="transport glass">
+      <section class="transport glass" data-guide="player-transport">
         <audio
           ref="audioEl"
           :src="audioSrc"
@@ -162,7 +162,7 @@
       </section>
     </template>
 
-    <div v-else class="not-found glass">
+    <div v-else class="not-found glass" data-guide="player-empty">
       <el-icon><Headset /></el-icon>
       <h2>找不到这首作品</h2>
       <p>它可能已被删除，或仍在生成中。</p>

--- a/web/src/views/plugins/plugins.vue
+++ b/web/src/views/plugins/plugins.vue
@@ -10,7 +10,7 @@
 
     <div class="status-banner" :class="{ active: enabled }"><div class="status-mark"><el-icon><CircleCheck /></el-icon></div><div class="status-copy"><strong>{{ enabled ? '扩展能力已接入当前工作流' : '扩展能力当前处于暂停状态' }}</strong><span>{{ enabled ? '已授权的插件页面和翻唱钩子可以正常使用。' : '开启后仍需单独启用每个插件，现有翻唱流程不会受到影响。' }}</span></div><span class="status-count">{{ plugins.length }} 个已安装</span></div>
 
-    <section class="settings glass">
+    <section class="settings glass" data-guide="plugin-settings">
       <div class="section-head">
         <div class="section-title"><span class="section-kicker">01</span><div><h2>插件功能</h2><p>控制扩展运行环境与市场来源</p></div></div>
       </div>
@@ -26,7 +26,7 @@
       </div>
     </section>
 
-    <section v-if="market.length" class="section">
+    <section v-if="market.length" class="section" data-guide="plugin-market">
       <div class="section-head"><div class="section-title"><span class="section-kicker">02</span><div><h2>插件市场</h2><p>兼容 NoneBot2 风格 plugins.json5 索引</p></div></div><span class="section-note">NONEBOT2 / GITHUB JSON5</span></div>
       <div class="plugin-grid">
         <article v-for="item in market" :key="item.id" class="plugin-card glass">
@@ -38,7 +38,7 @@
       </div>
     </section>
 
-    <section class="section">
+    <section class="section" data-guide="plugin-installed">
       <div class="section-head"><div class="section-title"><span class="section-kicker">03</span><div><h2>已安装插件</h2><p>每个插件都需要单独授权后才能运行</p></div></div><span class="section-note">LOCAL RUNTIME</span></div>
       <div v-if="plugins.length" class="plugin-grid">
         <article v-for="plugin in plugins" :key="plugin.id" class="plugin-card glass">

--- a/web/src/views/works/works.vue
+++ b/web/src/views/works/works.vue
@@ -15,7 +15,7 @@
     </div>
 
     <!-- 工具条 -->
-    <div class="toolbar">
+    <div class="toolbar" data-guide="works-filter">
       <div class="seg">
         <button
           v-for="t in tabs"
@@ -35,7 +35,7 @@
     </div>
 
     <!-- 作品列表 -->
-    <div v-if="filteredWorks.length" class="works glass">
+    <div v-if="filteredWorks.length" class="works glass" data-guide="works-list">
       <div class="works-th">
         <span class="col-title">作品</span>
         <span class="col-model">使用模型</span>


### PR DESCRIPTION
## 变更背景

本次更新覆盖模型管理、AI 翻唱导入、单模型/多模型推理、实时翻唱、音频编辑器、高音保护和首次使用引导，重点解决高音哑音、参数预设污染、拖拽导入和新用户不会使用等问题。

## 主要变更

### 模型管理

- 支持在“我的模型”中重命名模型。
- 增加模型重命名 API、Bridge、Service 和前端状态管理。
- 模型名称修改后保持持久化。
- 模型列表增加重命名入口和引导定位标记。

### AI 翻唱音频导入

- 支持点击选择音频文件。
- 支持拖拽音频导入。
- 首页拖拽音频后自动跳转到 AI 翻唱工作台。
- 拖拽的音频会自动填充到翻唱工作台。
- 首页直接点击入口仍保持跳转到 AI 翻唱工作台。
- 增加待处理音频状态传递，避免页面跳转后丢失导入文件。

### 全参数手动调整

- 增加“开启全参数手动调整”开关，默认关闭。
- 关闭全参数时，用户保存的高级参数不会影响普通翻唱。
- 预设中的高级参数不会污染默认模式。
- 开启全参数后支持调整对应模型可用的完整推理参数，包括：
  - F0 提取方式
  - F0 过滤阈值
  - 音高偏移
  - 扩散比例
  - 主模型 / 扩散模型比例
  - 目标说话人 / 音色 ID
  - Index 相关参数
  - 高音保护起点
  - 高音保护轮次
  - 其他模型特定参数
- 高音保护起点、F0 过滤阈值、目标说话人 / 音色 ID 仅在开启全参数时显示。
- 高音保护轮次仅在开启全参数且启用高音保护时显示。
- 普通模式继续使用稳定默认参数，不降低原有翻唱效果。

### 推理流程支持

全参数和高音保护逻辑同步支持：

- 单模型翻唱
- 多模型翻唱
- 实时翻唱
- 音频编辑器重新推理
- 音频编辑器中的模型片段重跑

### 高音保护优化

- 推理前先执行原始输入的基线推理。
- 只有检测到模型失配哑音后才启动保护重试。
- 根据实际模型输出的失配片段动态降低保护起点。
- 高音保护轮次由用户在全参数模式下控制。
- 实时翻唱继续使用独立的固定默认保护阈值。
- 高音保护不再对整首歌曲盲目处理。
- 新增失配区间限制，只对确认出现模型失配的时间段执行降调和升调恢复。
- 正常高音区域继续使用原始推理结果，减少音色变化、失帧和电音问题。
- 严格高音区优先，只有确认失配区间没有覆盖时才使用迟滞阈值兜底。
- 保留双声道、采样率和音频时长一致性。
- 增加输出音频有效性检查，避免空音频、能量塌陷或异常时长进入后续流程。
- 清理无用的重试缓存，同时保留编辑器仍需要的音频文件。

### 音频编辑器

- 编辑器重新推理支持全参数调整。
- 支持 F0 过滤阈值、目标音色 ID、高音保护起点和高音保护轮次。
- 编辑器关闭全参数后不会继承高级预设中的推理参数。
- 高音保护同样限制在确认的失配区间内，避免影响其他正常片段。

### AI 翻唱工作台与实时翻唱 UI

- 翻唱工作台试听增加可拖动进度条。
- 优化推理参数、高音保护和 AI 增强组件布局。
- AI 增强功能增加对应的参数和状态展示。
- 实时翻唱增加完整参数入口和高音保护状态。
- 多模型模式增加模型参数和时间轴相关引导。

### 首次使用交互式引导

新增首次使用交互式引导动画：

- 自动定位并框选当前功能组件。
- 通过弹出说明解释组件作用和使用方式。
- 支持页面跳转后继续引导。
- 支持跳过引导。
- 覆盖首页、音频导入、单模型翻唱、多模型翻唱、前期人声处理、推理参数、AI 增强、实时翻唱、音频编辑器、作品管理、播放器、模型管理和 API 等主要功能。
- 多模型时间轴引导时会自动调出时间轴组件。
- AI 增强引导时会自动开启增强功能，介绍结束后恢复默认状态。
- 模型重命名、推理参数、高音保护、主模型 / 扩散模型比例等具体控件均增加对应引导定位。

## 后端改动

- 扩展 `InferenceParams` 参数模型。
- 增加全参数开关和高音保护轮次解析。
- 增加旧参数兼容处理。
- 增加模型重命名接口。
- 增加高音保护区间 JSON 传递。
- `formant_pitch_worker` 支持限制处理区间。
- `ffmpeg_tool` 支持向高音保护 worker 传递指定失配区间。
- 转换服务、实时翻唱服务和音频编辑器服务统一使用局部保护策略。
- 增加高音保护重试结果选择和音频缓存清理逻辑。

## 前端改动

- 新增首次使用引导组件 `FirstUseGuide.vue`。
- 更新首页、模型管理、翻唱工作台、实时翻唱、编辑器和作品页面。
- 更新 API 类型、Mock API、Store 和 Bridge 调用。
- 增加首页拖拽音频跳转状态管理。
- 增加模型重命名交互。
- 增加完整推理参数表单和条件显示逻辑。
- 增加试听进度条和多模型时间轴引导。
