### PR TITLE
防止美声工程异常 PSOLA 导致风扇感

### DIFF
--- a/app/infrastructure/vocal_enhancement.py
+++ b/app/infrastructure/vocal_enhancement.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -25,6 +26,10 @@ class VocalEnhancementProcessor:
     DEFAULT_AI_EXCITER = 0.25
     DEFAULT_STEREO_WIDTH = 0.30
     DEFAULT_LOUDNESS_ENVELOPE = 0.58
+    # Large Praat resynthesis or local timing offsets create a periodic
+    # fan-like artifact. Keep normal tuning results, but reject unstable ones.
+    MAX_SAFE_TUNING_PSOLA_PERCENT = 75.0
+    MAX_SAFE_TUNING_ALIGNMENT_MS = 60.0
 
     @property
     def available(self) -> bool:
@@ -354,10 +359,49 @@ class VocalEnhancementProcessor:
             return False
         self._append_log(log_file, cmd, proc, "Praat AI 对齐/自然修音")
         if proc.returncode == 0 and output.is_file():
+            accepted, reason = self._accept_natural_tuning(proc.stdout)
+            if not accepted:
+                self._append_message(
+                    log_file,
+                    f"AI 对齐/自然修音结果不稳定，已回退原始人声：{reason}",
+                )
+                return False
             return True
         detail = self._error_tail(proc.stdout, proc.stderr)
         self._append_message(log_file, f"AI 对齐/自然修音失败，继续原始增强：{detail}")
         return False
+
+    @classmethod
+    def _accept_natural_tuning(cls, stdout: str | None) -> tuple[bool, str]:
+        """Reject only tuning renders likely to contain a fan-like PSOLA artifact."""
+        text = str(stdout or "")
+        if "VOCAL_TUNE_OK" not in text:
+            # Older workers did not expose quality statistics; retain compatibility.
+            return True, ""
+
+        def metric(name: str) -> float | None:
+            match = re.search(
+                rf"\b{re.escape(name)}=([0-9]+(?:\.[0-9]+)?)",
+                text,
+                flags=re.IGNORECASE,
+            )
+            if not match:
+                return None
+            try:
+                return float(match.group(1))
+            except ValueError:
+                return None
+
+        psola_percent = metric("psola")
+        alignment_ms = metric("align_max")
+        if (
+            psola_percent is not None
+            and psola_percent > cls.MAX_SAFE_TUNING_PSOLA_PERCENT
+        ):
+            return False, f"PSOLA 重合成占比 {psola_percent:.0f}%"
+        if alignment_ms is not None and alignment_ms > cls.MAX_SAFE_TUNING_ALIGNMENT_MS:
+            return False, f"局部对齐偏移 {alignment_ms:.0f}ms"
+        return True, ""
 
     @staticmethod
     def _append_log(

--- a/app/tests/test_vocal_enhancement.py
+++ b/app/tests/test_vocal_enhancement.py
@@ -1841,3 +1841,53 @@ def test_processor_continues_when_natural_tuning_fails(tmp_path: Path) -> None:
         )
 
     assert result == output
+
+
+def test_processor_rejects_unstable_natural_tuning_result(tmp_path: Path) -> None:
+    source = tmp_path / "source.wav"
+    reference = tmp_path / "reference.wav"
+    output = tmp_path / "enhanced.wav"
+    vocal_python = tmp_path / "vocal-python.exe"
+    vocal_worker = tmp_path / "vocal-worker.py"
+    tuning_worker = tmp_path / "tuning-worker.py"
+    marker = tmp_path / "runtime.ready"
+    cache_home = tmp_path / "cache"
+    for path in (
+        source,
+        reference,
+        vocal_python,
+        vocal_worker,
+        tuning_worker,
+        marker,
+    ):
+        path.write_bytes(b"ready")
+
+    def fake_run(cmd: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        if cmd[1] == str(tuning_worker):
+            Path(cmd[cmd.index("--output") + 1]).write_bytes(b"RIFF-tuned")
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                "VOCAL_TUNE_OK align_max=86ms psola=91%",
+                "",
+            )
+        assert Path(cmd[cmd.index("--input") + 1]) == source
+        output.write_bytes(b"RIFF-enhanced")
+        return subprocess.CompletedProcess(cmd, 0, "VOCAL_ENHANCE_OK", "")
+
+    with (
+        patch.object(config, "VOCAL_ENHANCEMENT_PYTHON", vocal_python),
+        patch.object(config, "VOCAL_ENHANCEMENT_WORKER", vocal_worker),
+        patch.object(config, "VOCAL_ENHANCEMENT_MARKER", marker),
+        patch.object(config, "VOCAL_ENHANCEMENT_MODEL_DIR", cache_home),
+        patch.object(config, "VOCAL_TUNING_WORKER", tuning_worker),
+        patch("infrastructure.vocal_enhancement.subprocess.run", side_effect=fake_run),
+    ):
+        result = VocalEnhancementProcessor().enhance(
+            source,
+            output,
+            reference=reference,
+        )
+
+    assert result == output
+    assert output.read_bytes() == b"RIFF-enhanced"


### PR DESCRIPTION
部分歌曲经过 AI 美声工程后，会出现类似“对着风扇唱歌”的周期性噪声和音色旋转感。

问题来自 Praat 自然修音结果异常：

- PSOLA 重合成占比过高
- 局部时间对齐偏移过大
- 几乎整段音频都被重新合成，导致音频质量下降

## 修改内容

- 在 `VocalEnhancementProcessor` 中增加自然修音结果质量检查。
- 解析自然修音 worker 输出的 `VOCAL_TUNE_OK` 统计信息。
- 当满足以下任一条件时，判定自然修音结果不稳定：
  - `psola > 75%`
  - `align_max > 60ms`
- 检测到异常后自动放弃本次自然修音结果，回退到原始输入音频。
- 回退后仍然继续执行后续 AI 人声增强流程，不会导致整条任务失败。
- 对旧版 worker 保持兼容：如果没有返回统计字段，则继续使用原有流程。
- 增加异常自然修音结果的单元测试。

## 影响范围

- 正常的自然修音结果不受影响。
- 只有检测到高风险 PSOLA 或异常局部对齐时才会自动回退。
- 不修改模型推理、DeepFilterNet3、高音保护和最终混音逻辑。
- 可避免异常自然修音结果污染整首歌曲。
