### PR TITLE
修复 So-VITS-SVC 推理异常与高频噪声问题

### DIFF
--- a/app/infrastructure/inference_naturalizer.py
+++ b/app/infrastructure/inference_naturalizer.py
@@ -167,6 +167,114 @@ def _source_on_output_timeline(source: Any, output_frames: int) -> Any:
     return result
 
 
+def _source_guided_high_band_repair(
+    source: Any,
+    output: Any,
+    sample_rate: int,
+    source_rate: int,
+    engine: str,
+) -> tuple[Any, dict[str, float]]:
+    """Attenuate only short HF bursts unsupported by the input vocal.
+
+    This is deliberately limited to So-VITS-SVC output. It does not copy source
+    samples: the source only supplies a broad high-band-to-body envelope used to
+    identify model-generated bursts.
+    """
+    import numpy as np
+
+    data = np.asarray(output, dtype=np.float32)
+    if (
+        engine != "so-vits-svc"
+        or sample_rate < 16000
+        or len(data) < 256
+        or not len(source)
+    ):
+        return data, {"guarded_frames": 0.0, "reduction_db": 0.0}
+    try:
+        from scipy.ndimage import gaussian_filter1d, uniform_filter1d
+        from scipy.signal import butter, sosfiltfilt
+    except ImportError:
+        return data, {"guarded_frames": 0.0, "reduction_db": 0.0}
+
+    source_mono = _source_on_output_timeline(source, len(data))
+    output_mono = np.mean(data, axis=1, dtype=np.float64)
+    nyquist = sample_rate * 0.5
+    high_cutoff = min(5600.0, nyquist * 0.72)
+    body_high = min(4800.0, nyquist * 0.58)
+    if body_high <= 700.0:
+        return data, {"guarded_frames": 0.0, "reduction_db": 0.0}
+    high_sos = butter(4, high_cutoff, btype="highpass", fs=sample_rate, output="sos")
+    body_sos = butter(
+        4,
+        [180.0, body_high],
+        btype="bandpass",
+        fs=sample_rate,
+        output="sos",
+    )
+    source_high = sosfiltfilt(high_sos, source_mono)
+    output_high = sosfiltfilt(high_sos, output_mono)
+    source_body = sosfiltfilt(body_sos, source_mono)
+    output_body = sosfiltfilt(body_sos, output_mono)
+    frame_size = max(64, int(round(sample_rate * 0.020)))
+    source_high_rms = _frame_rms(source_high, frame_size)
+    output_high_rms = _frame_rms(output_high, frame_size)
+    source_body_rms = _frame_rms(source_body, frame_size)
+    output_body_rms = _frame_rms(output_body, frame_size)
+    frames = min(
+        len(source_high_rms),
+        len(output_high_rms),
+        len(source_body_rms),
+        len(output_body_rms),
+    )
+    if frames < 3:
+        return data, {"guarded_frames": 0.0, "reduction_db": 0.0}
+    source_high_rms = source_high_rms[:frames]
+    output_high_rms = output_high_rms[:frames]
+    source_body_rms = source_body_rms[:frames]
+    output_body_rms = output_body_rms[:frames]
+    source_ratio = 20.0 * np.log10(
+        (source_high_rms + 1e-7) / (source_body_rms + 1e-7)
+    )
+    output_ratio = 20.0 * np.log10(
+        (output_high_rms + 1e-7) / (output_body_rms + 1e-7)
+    )
+    excess = output_ratio - source_ratio
+    source_active = source_body_rms >= max(
+        float(np.percentile(source_body_rms, 65)) * 0.03,
+        1e-5,
+    )
+    output_high_db = 20.0 * np.log10(output_high_rms + 1e-7)
+    suspicious = source_active & (output_high_db > -58.0) & (excess > 10.0)
+    anomaly = np.clip((excess - 10.0) / 8.0, 0.0, 1.0)
+    anomaly *= np.clip((output_high_db + 58.0) / 12.0, 0.0, 1.0)
+    anomaly[~suspicious] = 0.0
+    anomaly = gaussian_filter1d(anomaly, sigma=1.0, mode="nearest")
+    frame_gain = 1.0 - 0.85 * anomaly
+    centres = np.minimum(
+        len(data) - 1,
+        np.arange(frames, dtype=np.float64) * frame_size + frame_size * 0.5,
+    )
+    gain = np.interp(
+        np.arange(len(data), dtype=np.float64),
+        centres,
+        frame_gain,
+        left=float(frame_gain[0]),
+        right=float(frame_gain[-1]),
+    )
+    repaired = data.astype(np.float64, copy=True)
+    high_channels = sosfiltfilt(high_sos, repaired, axis=0)
+    repaired = repaired - high_channels + high_channels * gain[:, np.newaxis]
+    peak = float(np.max(np.abs(repaired))) if repaired.size else 0.0
+    if peak > 0.999:
+        repaired *= 0.999 / peak
+    guarded = float(np.count_nonzero(suspicious))
+    reduction = float(np.min(20.0 * np.log10(frame_gain[suspicious] + 1e-7))) if guarded else 0.0
+    return repaired.astype(np.float32), {
+        "guarded_frames": guarded,
+        "reduction_db": reduction,
+    }
+
+
 def naturalize_inference_output(
     source_path: str | Path,
     output_path: str | Path,
@@ -196,6 +304,14 @@ def naturalize_inference_output(
         output = output[:expected_frames]
     elif len(output) < expected_frames:
         output = np.pad(output, ((0, expected_frames - len(output)), (0, 0)))
+
+    output, high_band_stats = _source_guided_high_band_repair(
+        source,
+        output,
+        sample_rate,
+        source_rate,
+        engine,
+    )
 
     frame_size = max(32, int(round(sample_rate * 0.010)))
     source_mono = _source_on_output_timeline(source, len(output))
@@ -279,6 +395,8 @@ def naturalize_inference_output(
         "exact_silence_seconds": exact_frames * frame_size / sample_rate,
         "peak": peak,
         "peak_guard": peak_guard,
+        "high_band_guarded_frames": high_band_stats["guarded_frames"],
+        "high_band_reduction_db": high_band_stats["reduction_db"],
         "duration_adjustment_ms": duration_adjustment_ms,
     }
 
@@ -289,6 +407,7 @@ def format_naturalizer_stats(stats: dict[str, float]) -> str:
         f"silence=-{stats['silence_reduction_db']:.0f}dB "
         f"dynamics={stats['dynamic_min_db']:+.2f}..{stats['dynamic_max_db']:+.2f}dB "
         f"exact_silence={stats['exact_silence_seconds']:.2f}s "
+        f"hf_guard={int(stats.get('high_band_guarded_frames', 0.0))}frames "
         f"duration={stats['duration_adjustment_ms']:+.1f}ms "
         f"peak={stats['peak']:.4f}"
     )

--- a/app/infrastructure/svc_engine.py
+++ b/app/infrastructure/svc_engine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -42,6 +43,9 @@ class SvcEngine:
 
     # 强制切片时长（秒）：长音频按此切段逐段推理，控制显存峰值，避免 8GB 显存 OOM
     _CLIP_SECONDS = 30.0
+    # Windows 上 CUDA 子进程偶发原生退出时，进程不会留下 Python traceback 或 SVC_ERR。
+    # 在全新的子进程中仅重试一次，避免用户手动完整重跑前处理。
+    _UNSTRUCTURED_WORKER_RETRIES = 1
 
     @staticmethod
     def _ratio_to_kstep(diffusion_ratio: float) -> int:
@@ -262,46 +266,106 @@ class SvcEngine:
         env["PYTHONIOENCODING"] = "utf-8"
         env["PYTHONUTF8"] = "1"
 
-        try:
-            proc = subprocess.run(
-                cmd,
-                cwd=str(repo),
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                env=env,
-                timeout=3600,
-                **config.subprocess_no_window(),
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            raise RuntimeError(f"推理子进程启动失败: {exc}") from exc
+        processes = []
+        for attempt in range(self._UNSTRUCTURED_WORKER_RETRIES + 1):
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    cwd=str(repo),
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    env=env,
+                    timeout=3600,
+                    **config.subprocess_no_window(),
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise RuntimeError(f"推理子进程启动失败: {exc}") from exc
+            processes.append(proc)
+
+            if not self._should_retry_unstructured_failure(proc, out_path):
+                break
+            if attempt < self._UNSTRUCTURED_WORKER_RETRIES:
+                # 让 CUDA 驱动完成退出进程的资源回收，再使用全新的解释器重试。
+                try:
+                    out_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                time.sleep(1.0)
+
+        proc = processes[-1]
 
         # 把子进程完整输出写入作品日志，便于排查
         if log_file is not None:
             try:
                 with log_file.open("a", encoding="utf-8") as f:
                     f.write("\n----- so-vits-svc 推理输出 -----\n")
-                    f.write("$ " + " ".join(cmd) + "\n")
-                    f.write((proc.stdout or "") + "\n")
-                    if proc.stderr:
-                        f.write("----- stderr -----\n" + proc.stderr + "\n")
+                    for index, result in enumerate(processes, start=1):
+                        if len(processes) > 1:
+                            f.write(f"----- 第 {index}/{len(processes)} 次推理尝试 -----\n")
+                        f.write("$ " + " ".join(cmd) + "\n")
+                        f.write((result.stdout or "") + "\n")
+                        if result.stderr:
+                            f.write("----- stderr -----\n" + result.stderr + "\n")
+                        f.write(f"----- 子进程退出码 -----\n{result.returncode}\n")
             except OSError:
                 pass
 
         if proc.returncode != 0 or not out_path.exists():
             tail = self._error_tail(proc.stdout, proc.stderr)
-            raise RuntimeError(f"so-vits-svc 推理失败: {tail}")
+            reason = self._returncode_reason(proc.returncode)
+            raise RuntimeError(
+                f"so-vits-svc 推理失败（子进程退出码 {proc.returncode}{reason}）: {tail}"
+            )
+
+    @staticmethod
+    def _has_structured_worker_error(stdout: str | None, stderr: str | None) -> bool:
+        return any(
+            line.strip().startswith("SVC_ERR")
+            for line in f"{stdout or ''}\n{stderr or ''}".splitlines()
+        )
+
+    @classmethod
+    def _should_retry_unstructured_failure(cls, proc, out_path: Path) -> bool:  # noqa: ANN001
+        """Retry only a native/abrupt worker exit that gave no actionable error."""
+        return (
+            (proc.returncode != 0 or not out_path.exists())
+            and not cls._has_structured_worker_error(proc.stdout, proc.stderr)
+        )
+
+    @staticmethod
+    def _returncode_reason(returncode: int) -> str:
+        """Make common Windows native crash statuses actionable in the UI."""
+        status = int(returncode) & 0xFFFFFFFF
+        known = {
+            0xC0000005: "，Windows 原生崩溃/访问冲突 0xC0000005",
+            0xC0000017: "，Windows 虚拟内存不足 0xC0000017",
+            0xC0000409: "，Windows 原生快速失败 0xC0000409",
+        }
+        return known.get(status, "")
 
     @staticmethod
     def _error_tail(stdout: str | None, stderr: str | None) -> str:
         """提取子进程输出的关键错误信息（优先 SVC_ERR 行，否则取末尾几行）。"""
         text = ((stdout or "") + "\n" + (stderr or "")).strip()
+        lower = text.lower()
+        if "cuda error: out of memory" in lower or "torch.cuda.outofmemoryerror" in lower:
+            return "CUDA 显存不足：请关闭占用显卡的软件后重试，或改用更短切片/CPU 推理。"
         for line in text.splitlines():
             if line.startswith("SVC_ERR"):
                 return line[len("SVC_ERR") :].strip()
-        lines = [ln for ln in text.splitlines() if ln.strip()]
-        return " | ".join(lines[-3:]) if lines else "未知错误"
+        lines = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip()
+            and "warning:" not in line.lower()
+            and "weightnorm.apply" not in line.lower()
+            and "set_audio_backend" not in line.lower()
+        ]
+        if lines:
+            return " | ".join(lines[-3:])
+        return "推理子进程异常退出，未返回 Python 错误详情；已自动重试一次仍失败。"
 
     @staticmethod
     def _clear_output(out_path: Path) -> None:

--- a/app/tests/test_inference_naturalizer.py
+++ b/app/tests/test_inference_naturalizer.py
@@ -10,6 +10,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from infrastructure.inference_naturalizer import naturalize_inference_output
+from infrastructure.inference_naturalizer import _source_guided_high_band_repair
 from infrastructure.seedvc_engine import SeedVcEngine
 
 
@@ -131,3 +132,34 @@ def test_seedvc_quality_range_avoids_low_step_artifacts() -> None:
     assert SeedVcEngine._diffusion_steps(0.0) == 20
     assert SeedVcEngine._diffusion_steps(0.5) == 35
     assert SeedVcEngine._diffusion_steps(1.0) == 50
+
+
+def test_source_guided_high_band_repair_only_attenuates_unsupported_burst() -> None:
+    sample_rate = 24000
+    time = np.arange(sample_rate * 2, dtype=np.float64) / sample_rate
+    source = 0.16 * np.sin(2.0 * np.pi * 220.0 * time)
+    output = source.copy()
+    burst = (time >= 0.80) & (time < 0.90)
+    output[burst] += 0.12 * np.sin(2.0 * np.pi * 8200.0 * time[burst])
+
+    repaired, stats = _source_guided_high_band_repair(
+        source[:, np.newaxis],
+        output[:, np.newaxis],
+        sample_rate,
+        sample_rate,
+        "so-vits-svc",
+    )
+
+    from scipy.signal import butter, sosfiltfilt
+
+    highpass = butter(4, 5600.0, btype="highpass", fs=sample_rate, output="sos")
+    core = (time >= 0.82) & (time < 0.88)
+    before_high = sosfiltfilt(highpass, output)[core]
+    after_high = sosfiltfilt(highpass, repaired[:, 0])[core]
+    bodypass = butter(4, [180.0, 4800.0], btype="bandpass", fs=sample_rate, output="sos")
+    before_body = sosfiltfilt(bodypass, output)[core]
+    after_body = sosfiltfilt(bodypass, repaired[:, 0])[core]
+
+    assert stats["guarded_frames"] > 0.0
+    assert np.sqrt(np.mean(after_high**2)) < np.sqrt(np.mean(before_high**2)) * 0.40
+    assert np.sqrt(np.mean(after_body**2)) > np.sqrt(np.mean(before_body**2)) * 0.85

--- a/app/tests/test_inference_regressions.py
+++ b/app/tests/test_inference_regressions.py
@@ -86,6 +86,62 @@ def test_sovits_fork_k_step_config_is_supported() -> None:
     assert _resolve_diffusion_k_step(svc, 200, 1.0) == (300, 300)
 
 
+def test_sovits_retries_unstructured_worker_crash_and_records_exit_codes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import infrastructure.svc_engine as svc_engine_module
+
+    source = tmp_path / "vocals.wav"
+    output = tmp_path / "converted.wav"
+    log_file = tmp_path / "run.log"
+    calls = 0
+
+    def run_worker(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            output.write_bytes(b"partial")
+            return SimpleNamespace(
+                returncode=-1073741819,
+                stdout="load model",
+                stderr="WeightNorm.apply(module, name, dim)\nwarning: backend deprecated",
+            )
+        output.write_bytes(b"wave")
+        return SimpleNamespace(returncode=0, stdout="SVC_OK converted.wav", stderr="")
+
+    monkeypatch.setattr(svc_engine_module.subprocess, "run", run_worker)
+    monkeypatch.setattr(svc_engine_module.time, "sleep", lambda _seconds: None)
+
+    SvcEngine()._run_worker(
+        "model.pth",
+        "config.json",
+        "",
+        "",
+        source,
+        output,
+        InferenceParams(),
+        log_file,
+    )
+
+    logged = log_file.read_text(encoding="utf-8")
+    assert calls == 2
+    assert output.is_file()
+    assert "第 1/2 次推理尝试" in logged
+    assert "-1073741819" in logged
+    assert "第 2/2 次推理尝试" in logged
+
+
+def test_sovits_error_tail_never_reports_deprecation_warning_as_root_cause() -> None:
+    detail = SvcEngine()._error_tail(
+        "",
+        "WeightNorm.apply(module, name, dim)\n"
+        "infer_tool.py: UserWarning: set_audio_backend deprecated",
+    )
+
+    assert "异常退出" in detail
+    assert "WeightNorm" not in detail
+
+
 @pytest.mark.parametrize(
     ("engine", "model", "params", "message"),
     [


### PR DESCRIPTION
## 背景

部分 So-VITS-SVC 推理任务存在以下问题：

- 推理子进程偶发无 traceback 直接退出，日志无法定位原因。
- `converted_raw.wav` 在部分时间段出现模型输出产生的异常高频声。
- 高频异常会继续进入后续修复和增强流程，最终影响 `converted.wav`。
- 旧日志中的 `WeightNorm.apply`、`set_audio_backend` 等警告容易被误认为推理失败原因。

## 变更内容

### 1. 增加 So-VITS-SVC 推理异常重试

修改 `app/infrastructure/svc_engine.py`：

- 对没有返回 `SVC_ERR` 的异常退出进行一次自动重试。
- 重试前删除不完整的输出文件。
- 记录每一次推理尝试、退出码和标准错误。
- 增加 Windows 常见原生崩溃码说明：
  - `0xC0000005`：访问冲突
  - `0xC0000017`：虚拟内存不足
  - `0xC0000409`：原生快速失败
- 增加 CUDA 显存不足的明确错误提示。
- 过滤 `WeightNorm.apply`、`set_audio_backend` 等警告，避免污染真正的错误原因。

### 2. 增加 So-VITS-SVC 输出高频异常保护

修改 `app/infrastructure/inference_naturalizer.py`：

- 仅针对 `so-vits-svc` 推理输出启用源引导高频检测。
- 使用输入人声作为能量参考，不复制输入人声的音色或波形。
- 按 20 ms 帧比较：
  - 输出高频能量
  - 输入高频能量
  - 输出与输入主体频段的比例
- 仅当输出高频相对输入异常增加超过阈值时进行处理。
- 只衰减异常高频分量，不修改主体频段、整体音量和原始音色。
- 保留高频保护统计信息到 `SVC_NATURAL` 日志，例如：

```text
hf_guard=805frames